### PR TITLE
Drop unused `use function strstr` in ClassGenerator

### DIFF
--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -29,7 +29,6 @@ use function sprintf;
 use function str_replace;
 use function strpos;
 use function strrpos;
-use function strstr;
 use function strtolower;
 use function substr;
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes
