### PR TITLE
QA fix for phpstan

### DIFF
--- a/src/Generator/Exception/ClassNotFoundException.php
+++ b/src/Generator/Exception/ClassNotFoundException.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-code for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-code/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-code/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\Code\Generator\Exception;
+
+class ClassNotFoundException extends RuntimeException implements
+    ExceptionInterface
+{
+}

--- a/src/Generator/FileGenerator.php
+++ b/src/Generator/FileGenerator.php
@@ -10,6 +10,7 @@ namespace Laminas\Code\Generator;
 
 use Laminas\Code\DeclareStatement;
 use Laminas\Code\Exception\InvalidArgumentException;
+use Laminas\Code\Generator\Exception\ClassNotFoundException;
 use Laminas\Code\Reflection\Exception as ReflectionException;
 use Laminas\Code\Reflection\FileReflection;
 
@@ -335,18 +336,28 @@ class FileGenerator extends AbstractGenerator
     }
 
     /**
-     * @param  string $name
+     * @param string $name
+     *
      * @return ClassGenerator
+     * @throws ClassNotFoundException
      */
     public function getClass($name = null)
     {
         if ($name === null) {
             reset($this->classes);
+            $class = current($this->classes);
+            if (false === $class) {
+                throw new ClassNotFoundException('No class is set');
+            }
 
-            return current($this->classes);
+            return $class;
         }
 
-        return $this->classes[(string) $name];
+        if (false === array_key_exists($name, $this->classes)) {
+            throw new ClassNotFoundException(sprintf('Class %s is not set', $name));
+        }
+
+        return $this->classes[(string)$name];
     }
 
     /**

--- a/test/Generator/FileGeneratorTest.php
+++ b/test/Generator/FileGeneratorTest.php
@@ -11,6 +11,7 @@ namespace LaminasTest\Code\Generator;
 use Laminas\Code\DeclareStatement;
 use Laminas\Code\Exception\InvalidArgumentException;
 use Laminas\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\Exception\ClassNotFoundException;
 use Laminas\Code\Generator\FileGenerator;
 use Laminas\Code\Reflection\FileReflection;
 use PHPUnit\Framework\TestCase;
@@ -163,6 +164,19 @@ class TestSampleSingleClass
 EOS;
 
         self::assertEquals($expectedOutput, $codeGenFileFromDisk->generate());
+    }
+
+    public function testClassNotFoundException()
+    {
+        $fileGenerator = new FileGenerator();
+
+        $this->expectException(ClassNotFoundException::class);
+        $this->expectExceptionMessage('No class is set');
+        $fileGenerator->getClass();
+
+        $this->expectException(ClassNotFoundException::class);
+        $this->expectExceptionMessage('Class TestClass is not set');
+        $fileGenerator->getClass('TestClass');
     }
 
     /**


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

Small return type hint update to stop phpstan complaining.

It can return false when the array is empty, we check on that in the code, but because the type hint does not contain false, phpstan complains that the condition is always true (which it isn't in reality)


