### PR TITLE
#53 support php-8.0 type system additions

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -15,7 +15,7 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "7.4"
+          - "8.0"
         operating-system:
           - "ubuntu-latest"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,18 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [laminas/laminas-code#57](https://github.com/laminas/laminas-code/pull/57) support for following PHP 8
+  types have been added:
+   * union types
+   * `false`
+   * `mixed`
+   * `null`
+   * `static`
 
 ### Changed
 
+- [laminas/laminas-code#57](https://github.com/laminas/laminas-code/pull/57) due to internal refactoring
+  requiring better internal types, the minimum supported PHP version is now `7.4`
 - BC BREAK [laminas/laminas-code#38](https://github.com/laminas/laminas-code/pull/38) changed generated class
   output to no longer contain excessive whitespace around contents. The structure of the generated output
   will still be the same, but spacing changed, which will likely lead o breakages if you

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "^7.4 || ~8.0.0",
         "laminas/laminas-eventmanager": "^3.3"
     },
     "require-dev": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -109,10 +109,8 @@
       <code>generate</code>
       <code>removeTrait</code>
     </MissingReturnType>
-    <MixedArgument occurrences="15">
+    <MixedArgument occurrences="13">
       <code>$array['name']</code>
-      <code>$implemented</code>
-      <code>$implementedInterface</code>
       <code>$this-&gt;traitUsageGenerator-&gt;generate()</code>
       <code>$value</code>
       <code>$value</code>
@@ -126,7 +124,8 @@
       <code>array_values($method)</code>
       <code>array_values($property)</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion occurrences="2">
+      <code>$interfaces</code>
       <code>$name</code>
     </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="7">
@@ -538,9 +537,6 @@
       <code>$parameter</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedOperand occurrences="1">
-      <code>$this-&gt;returnType-&gt;generate()</code>
-    </MixedOperand>
     <PossiblyFalseArgument occurrences="1">
       <code>$reflectionMethod-&gt;getDocBlock()</code>
     </PossiblyFalseArgument>
@@ -556,9 +552,6 @@
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(bool) $returnsReference</code>
     </RedundantCastGivenDocblockType>
-    <RedundantCondition occurrences="1">
-      <code>method_exists($methodReflection, 'getReturnType')</code>
-    </RedundantCondition>
     <UnsafeInstantiation occurrences="2">
       <code>new static($array['name'])</code>
       <code>new static()</code>
@@ -587,14 +580,7 @@
     <MixedAssignment occurrences="1">
       <code>$value</code>
     </MixedAssignment>
-    <MixedOperand occurrences="1">
-      <code>$this-&gt;type-&gt;generate()</code>
-    </MixedOperand>
     <NullableReturnStatement occurrences="1"/>
-    <PossiblyNullReference occurrences="2">
-      <code>getName</code>
-      <code>getParentClass</code>
-    </PossiblyNullReference>
     <PropertyNotSetInConstructor occurrences="4">
       <code>$defaultValue</code>
       <code>$name</code>
@@ -607,10 +593,6 @@
       <code>(int) $position</code>
       <code>(string) $name</code>
     </RedundantCastGivenDocblockType>
-    <RedundantCondition occurrences="2">
-      <code>method_exists($reflectionParameter, 'getType')</code>
-      <code>method_exists($reflectionParameter, 'isVariadic')</code>
-    </RedundantCondition>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>$this-&gt;defaultValue instanceof ValueGenerator</code>
     </RedundantConditionGivenDocblockType>
@@ -797,27 +779,22 @@
     </MissingReturnType>
   </file>
   <file src="src/Generator/TypeGenerator.php">
-    <InvalidScalarArgument occurrences="4">
-      <code>$trimmedNullable</code>
-      <code>$trimmedType</code>
-      <code>$trimmedType</code>
-      <code>$trimmedType</code>
-    </InvalidScalarArgument>
-    <MissingReturnType occurrences="1">
-      <code>generate</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;generate()</code>
-    </MixedArgument>
-    <PossiblyInvalidPropertyAssignmentValue occurrences="2">
-      <code>$nullable</code>
-      <code>$trimmedType</code>
-    </PossiblyInvalidPropertyAssignmentValue>
-    <PropertyNotSetInConstructor occurrences="3">
-      <code>$isInternalPhpType</code>
-      <code>$nullable</code>
-      <code>$type</code>
-    </PropertyNotSetInConstructor>
+    <ImpureMethodCall occurrences="7">
+      <code>allowsNull</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getParentClass</code>
+      <code>getTypes</code>
+    </ImpureMethodCall>
+    <MixedArgument occurrences="1"/>
+  </file>
+  <file src="src/Generator/TypeGenerator/AtomicType.php">
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MoreSpecificReturnType occurrences="1">
+      <code>non-empty-string</code>
+    </MoreSpecificReturnType>
   </file>
   <file src="src/Generator/ValueGenerator.php">
     <DocblockTypeContradiction occurrences="2">
@@ -1338,9 +1315,13 @@
     </MissingReturnType>
   </file>
   <file src="test/Generator/ClassGeneratorTest.php">
-    <ArgumentTypeCoercion occurrences="2">
+    <ArgumentTypeCoercion occurrences="7">
+      <code>'Class1'</code>
       <code>'InvalidArgumentException'</code>
       <code>'LaminasTest_Code_NsTest_BarClass'</code>
+      <code>['Class1', 'Class2']</code>
+      <code>['Class1', 'Class2']</code>
+      <code>['Class1', 'Class2']</code>
     </ArgumentTypeCoercion>
     <InvalidArgument occurrences="5">
       <code>$resource</code>
@@ -1528,6 +1509,12 @@
       <code>getDefaultValue</code>
       <code>getDefaultValue</code>
     </PossiblyFalseReference>
+    <UndefinedClass occurrences="5">
+      <code>'Class1'</code>
+      <code>['Class1', 'Class2']</code>
+      <code>['Class1', 'Class2']</code>
+      <code>['Class1', 'Class2']</code>
+    </UndefinedClass>
   </file>
   <file src="test/Generator/DocBlock/Tag/AuthorTagTest.php">
     <MissingReturnType occurrences="5">
@@ -1718,6 +1705,9 @@
     </MissingReturnType>
   </file>
   <file src="test/Generator/InterfaceGeneratorTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>['Class1', 'Class2']</code>
+    </ArgumentTypeCoercion>
     <MissingReturnType occurrences="17">
       <code>testAbstractAccessorsReturnsFalse</code>
       <code>testClassNotAnInterfaceException</code>
@@ -1756,6 +1746,9 @@
       <code>isInterface</code>
       <code>isInterface</code>
     </PossiblyFalseReference>
+    <UndefinedClass occurrences="1">
+      <code>['Class1', 'Class2']</code>
+    </UndefinedClass>
   </file>
   <file src="test/Generator/MethodGeneratorTest.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -2041,12 +2034,11 @@
     </MixedAssignment>
   </file>
   <file src="test/Generator/TypeGeneratorTest.php">
-    <MissingReturnType occurrences="5">
+    <MissingReturnType occurrences="4">
       <code>testFromValidTypeString</code>
       <code>testIsAGenerator</code>
       <code>testRejectsInvalidTypeString</code>
       <code>testStringCastFromValidTypeString</code>
-      <code>testStripsPrefixingBackslashFromClassNames</code>
     </MissingReturnType>
   </file>
   <file src="test/Generator/ValueGeneratorTest.php">
@@ -2856,6 +2848,19 @@
       <code>nullableObjectParameter</code>
       <code>objectParameter</code>
     </MissingReturnType>
+  </file>
+  <file src="test/TestAsset/Php80Types.php">
+    <ReservedWord occurrences="9">
+      <code>bool|null</code>
+      <code>bool|null $parameter</code>
+      <code>bool|string|null</code>
+      <code>false|self</code>
+      <code>false|self $parameter</code>
+      <code>mixed</code>
+      <code>mixed</code>
+      <code>null|bool</code>
+      <code>null|bool $parameter</code>
+    </ReservedWord>
   </file>
   <file src="test/TestAsset/ReturnTypeHintedClass.php">
     <InvalidReturnType occurrences="10">

--- a/psalm.xml
+++ b/psalm.xml
@@ -40,8 +40,6 @@
                 <referencedMethod name="Laminas\Code\Scanner\DocBlockScanner::getShortDescription"/>
                 <referencedMethod name="Laminas\Code\Scanner\DocBlockScanner::getTags"/>
             </errorLevel>
-            <errorLevel type="suppress">
-            </errorLevel>
         </InternalMethod>
     </issueHandlers>
     <plugins>

--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -73,7 +73,9 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
     protected $extendedClass;
 
     /**
-     * @var array Array of string names
+     * @var string[] Array of string names
+     *
+     * @psalm-var array<class-string>
      */
     protected $implementedInterfaces = [];
 
@@ -470,7 +472,8 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
     }
 
     /**
-     * @param  array $implementedInterfaces
+     * @param string[] $implementedInterfaces
+     * @psalm-param array<class-string> $implementedInterfaces
      * @return self
      */
     public function setImplementedInterfaces(array $implementedInterfaces)
@@ -485,7 +488,9 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
     }
 
     /**
-     * @return array
+     * @return string
+     *
+     * @psalm-return array<class-string>
      */
     public function getImplementedInterfaces()
     {
@@ -508,6 +513,7 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
 
     /**
      * @param string $implementedInterface
+     * @psalm-param class-string $implementedInterface
      * @return self
      */
     public function removeImplementedInterface($implementedInterface)

--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -476,7 +476,8 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
     public function setImplementedInterfaces(array $implementedInterfaces)
     {
         array_map(function ($implementedInterface) {
-            return (string) TypeGenerator::fromTypeString($implementedInterface);
+            // This loop is just validating that the given `$implementedInterfaces` contains valid syntax/symbols
+            return TypeGenerator::fromTypeString($implementedInterface);
         }, $implementedInterfaces);
 
         $this->implementedInterfaces = $implementedInterfaces;
@@ -497,8 +498,12 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
      */
     public function hasImplementedInterface($implementedInterface)
     {
-        $implementedInterface = (string) TypeGenerator::fromTypeString($implementedInterface);
-        return in_array($implementedInterface, $this->implementedInterfaces);
+        $interfaceType = TypeGenerator::fromTypeString($implementedInterface);
+
+        return (bool) array_filter(
+            array_map([TypeGenerator::class, 'fromTypeString'], $this->implementedInterfaces),
+            static fn (TypeGenerator $interface) : bool => $interfaceType->equals($interface)
+        );
     }
 
     /**
@@ -507,8 +512,13 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
      */
     public function removeImplementedInterface($implementedInterface)
     {
-        $implementedInterface = (string) TypeGenerator::fromTypeString($implementedInterface);
-        unset($this->implementedInterfaces[array_search($implementedInterface, $this->implementedInterfaces)]);
+        $interfaceType = TypeGenerator::fromTypeString($implementedInterface);
+
+        $this->implementedInterfaces = array_filter(
+            array_map([TypeGenerator::class, 'fromTypeString'], $this->implementedInterfaces),
+            static fn (TypeGenerator $interface) : bool => ! $interfaceType->equals($interface)
+        );
+
         return $this;
     }
 

--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -15,7 +15,6 @@ use function explode;
 use function implode;
 use function is_array;
 use function is_string;
-use function method_exists;
 use function preg_replace;
 use function sprintf;
 use function str_replace;
@@ -82,7 +81,7 @@ class MethodGenerator extends AbstractMemberGenerator
         $method         = new static();
         $declaringClass = $reflectionMethod->getDeclaringClass();
 
-        $method->setReturnType(self::extractReturnTypeFromMethodReflection($reflectionMethod));
+        $method->returnType = TypeGenerator::fromReflectionType($reflectionMethod->getReturnType(), $declaringClass);
         $method->setFinal($reflectionMethod->isFinal());
 
         if ($reflectionMethod->isPrivate()) {
@@ -398,29 +397,6 @@ class MethodGenerator extends AbstractMemberGenerator
     public function __toString()
     {
         return $this->generate();
-    }
-
-    /**
-     * @param MethodReflection $methodReflection
-     *
-     * @return null|string
-     */
-    private static function extractReturnTypeFromMethodReflection(MethodReflection $methodReflection)
-    {
-        $returnType = method_exists($methodReflection, 'getReturnType')
-            ? $methodReflection->getReturnType()
-            : null;
-
-        if (! $returnType) {
-            return null;
-        }
-
-        if (! method_exists($returnType, 'getName')) {
-            return self::expandLiteralType((string) $returnType, $methodReflection);
-        }
-
-        return ($returnType->allowsNull() ? '?' : '')
-            . self::expandLiteralType($returnType->getName(), $methodReflection);
     }
 
     /**

--- a/src/Generator/TypeGenerator.php
+++ b/src/Generator/TypeGenerator.php
@@ -133,21 +133,23 @@ final class TypeGenerator implements GeneratorInterface
             if ($nullable) {
                 $types[0]->assertCanBeStandaloneNullable();
             }
-        } else {
-            if ($nullable) {
-                throw new InvalidArgumentException(sprintf(
-                    'Type "%s" is a union type, and therefore cannot be also marked nullable with the "?" prefix',
-                    $type
-                ));
-            }
 
-            foreach ($types as $index => $atomicType) {
-                $otherTypes = array_diff_key($types, array_flip([$index]));
+            return new self($types, $nullable);
+        }
 
-                assert([] !== $otherTypes, 'There are always 2 or more types in a union type');
+        if ($nullable) {
+            throw new InvalidArgumentException(sprintf(
+                'Type "%s" is a union type, and therefore cannot be also marked nullable with the "?" prefix',
+                $type
+            ));
+        }
 
-                $atomicType->assertCanUnionWith($otherTypes);
-            }
+        foreach ($types as $index => $atomicType) {
+            $otherTypes = array_diff_key($types, array_flip([$index]));
+
+            assert([] !== $otherTypes, 'There are always 2 or more types in a union type');
+
+            $atomicType->assertCanUnionWith($otherTypes);
         }
 
         return new self($types, $nullable);

--- a/src/Generator/TypeGenerator/AtomicType.php
+++ b/src/Generator/TypeGenerator/AtomicType.php
@@ -12,6 +12,7 @@ use Laminas\Code\Generator\Exception\InvalidArgumentException;
 
 use function array_filter;
 use function array_key_exists;
+use function assert;
 use function implode;
 use function preg_match;
 use function strtolower;
@@ -61,7 +62,7 @@ final class AtomicType
     private const VALID_IDENTIFIER_MATCHER = '/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*'
         . '(\\\\[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)*$/';
 
-    /** @psalm-var -1|one-of<self::BUILT_IN_TYPES_PRECEDENCE> */
+    /** @psalm-var value-of<AtomicType::BUILT_IN_TYPES_PRECEDENCE>|0 */
     public int $sortIndex;
 
     /** @psalm-var non-empty-string */
@@ -69,7 +70,7 @@ final class AtomicType
 
     /**
      * @psalm-param non-empty-string $type
-     * @psalm-param @psalm-var -1|one-of<self::BUILT_IN_TYPES_PRECEDENCE> $sortIndex
+     * @psalm-param value-of<AtomicType::BUILT_IN_TYPES_PRECEDENCE>|0 $sortIndex
      */
     private function __construct(string $type, int $sortIndex)
     {
@@ -109,7 +110,9 @@ final class AtomicType
             ));
         }
 
-        return new self($trimmedType, -1);
+        assert('' !== $trimmedType);
+
+        return new self($trimmedType, 0);
     }
 
     /** @psalm-pure */

--- a/src/Generator/TypeGenerator/AtomicType.php
+++ b/src/Generator/TypeGenerator/AtomicType.php
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-code for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-code/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-code/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\Code\Generator\TypeGenerator;
+
+use Laminas\Code\Generator\Exception\InvalidArgumentException;
+
+use function array_filter;
+use function array_key_exists;
+use function implode;
+use function preg_match;
+use function strtolower;
+use function substr;
+
+/**
+ * Represents a single/indivisible (atomic) type, as supported by PHP.
+ * This means that this object can be composed into more complex union, intersection
+ * and nullable types.
+ *
+ * @internal the {@see AtomicType} is an implementation detail of the type generator,
+ *
+ * @psalm-immutable
+ */
+final class AtomicType
+{
+    /**
+     * Built-in type sorting, ascending.
+     *
+     * @psalm-var array<non-empty-string, positive-int>
+     */
+    private const BUILT_IN_TYPES_PRECEDENCE = [
+        'bool'     => 1,
+        'int'      => 2,
+        'float'    => 3,
+        'string'   => 4,
+        'array'    => 5,
+        'callable' => 6,
+        'iterable' => 7,
+        'object'   => 8,
+        'static'   => 9,
+        'mixed'    => 10,
+        'void'     => 11,
+        'false'    => 12,
+        'null'     => 13,
+    ];
+
+    /** @psalm-var array<non-empty-string, null> */
+    private const NOT_NULLABLE_TYPES = [
+        'null' => null,
+        'false' => null,
+        'void' => null,
+        'mixed' => null,
+    ];
+
+    /** A regex pattern to match valid class/interface/trait names */
+    private const VALID_IDENTIFIER_MATCHER = '/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*'
+        . '(\\\\[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)*$/';
+
+    /** @psalm-var -1|one-of<self::BUILT_IN_TYPES_PRECEDENCE> */
+    public int $sortIndex;
+
+    /** @psalm-var non-empty-string */
+    public string $type;
+
+    /**
+     * @psalm-param non-empty-string $type
+     * @psalm-param @psalm-var -1|one-of<self::BUILT_IN_TYPES_PRECEDENCE> $sortIndex
+     */
+    private function __construct(string $type, int $sortIndex)
+    {
+        $this->type = $type;
+        $this->sortIndex = $sortIndex;
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function fromString(string $type): self
+    {
+        $trimmedType = '\\' === ($type[0] ?? '')
+            ? substr($type, 1)
+            : $type;
+        $lowerCaseType = strtolower($trimmedType);
+
+        if (array_key_exists($lowerCaseType, self::BUILT_IN_TYPES_PRECEDENCE)) {
+            if ($lowerCaseType !== strtolower($type)) {
+                throw new InvalidArgumentException(sprintf(
+                    'Provided type "%s" is a built-in type, and should not be prefixed with "\\"',
+                    $type
+                ));
+            }
+
+            return new self($lowerCaseType, self::BUILT_IN_TYPES_PRECEDENCE[$lowerCaseType]);
+        }
+
+        if (1 !== preg_match(self::VALID_IDENTIFIER_MATCHER, $trimmedType)) {
+            throw new InvalidArgumentException(sprintf(
+                'Provided type "%s" is not recognized as a valid expression: it must match "%s" or be one of the built-in types (%s)',
+                $type,
+                self::VALID_IDENTIFIER_MATCHER,
+                implode(', ', self::BUILT_IN_TYPES_PRECEDENCE)
+            ));
+        }
+
+        return new self($trimmedType, -1);
+    }
+
+    /** @psalm-pure */
+    public static function null(): self
+    {
+        return new self('null', self::BUILT_IN_TYPES_PRECEDENCE['null']);
+    }
+
+    /** @psalm-return non-empty-string */
+    public function fullyQualifiedName(): string
+    {
+        return array_key_exists($this->type, self::BUILT_IN_TYPES_PRECEDENCE)
+            ? $this->type
+            : '\\' . $this->type;
+    }
+
+    /**
+     * @psalm-param non-empty-array<self> $others
+     *
+     * @throws InvalidArgumentException
+     */
+    public function assertCanUnionWith(array $others): void
+    {
+        if ('mixed' === $this->type
+            || 'void' === $this->type
+        ) {
+            throw new InvalidArgumentException(sprintf(
+                'Type "%s" cannot be composed in a union with any other types',
+                $this->type
+            ));
+        }
+
+        foreach ($others as $other) {
+            if ($other->type === $this->type) {
+                throw new InvalidArgumentException(sprintf(
+                    'Type "%s" cannot be composed in a union with the same type "%s"',
+                    $this->type,
+                    $other->type
+                ));
+            }
+        }
+
+        if ($this->requiresUnionWithStandaloneType() &&
+            [] === array_filter($others, static fn (self $type) : bool => ! $type->requiresUnionWithStandaloneType())
+        ) {
+            throw new InvalidArgumentException(sprintf(
+                'Type "%s" requires to be composed with non-standalone types',
+                $this->type
+            ));
+        }
+    }
+
+    /** @throws InvalidArgumentException */
+    public function assertCanBeAStandaloneType(): void
+    {
+        if ($this->requiresUnionWithStandaloneType()) {
+            throw new InvalidArgumentException(sprintf(
+                'Type "%s" cannot be used standalone, and must be part of a union type',
+                $this->type
+            ));
+        }
+    }
+
+    /** @throws InvalidArgumentException */
+    public function assertCanBeStandaloneNullable(): void
+    {
+        if (array_key_exists($this->type, self::NOT_NULLABLE_TYPES)) {
+            throw new InvalidArgumentException(sprintf(
+                'Type "%s" cannot be nullable',
+                $this->type
+            ));
+        }
+    }
+
+    private function requiresUnionWithStandaloneType(): bool
+    {
+        return 'null' === $this->type || 'false' === $this->type;
+    }
+}

--- a/test/Generator/InterfaceGeneratorTest.php
+++ b/test/Generator/InterfaceGeneratorTest.php
@@ -8,6 +8,8 @@
 
 namespace LaminasTest\Code\Generator;
 
+use Countable;
+use IteratorAggregate;
 use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\Exception\InvalidArgumentException;
 use Laminas\Code\Generator\InterfaceGenerator;
@@ -248,7 +250,7 @@ CODE;
         $classGenerator->setName('MyCollection');
         $classGenerator->addMethod('isEmpty');
 
-        $classGenerator->setImplementedInterfaces(['Countable', 'IteratorAggregate']);
+        $classGenerator->setImplementedInterfaces([Countable::class, IteratorAggregate::class]);
 
         $expected = <<<CODE
 interface MyCollection extends Countable, IteratorAggregate

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -21,6 +21,7 @@ use LaminasTest\Code\TestAsset\InternalHintsClass;
 use LaminasTest\Code\TestAsset\IterableHintsClass;
 use LaminasTest\Code\TestAsset\NullableReturnTypeHintedClass;
 use LaminasTest\Code\TestAsset\ObjectHintsClass;
+use LaminasTest\Code\TestAsset\Php80Types;
 use LaminasTest\Code\TestAsset\ReturnTypeHintedClass;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -351,7 +352,7 @@ PHP;
     {
         $methodGenerator = MethodGenerator::fromReflection(new MethodReflection($className, $methodName));
 
-        self::assertStringMatchesFormat('%A) : ' . $expectedReturnSignature . '%A{%A', $methodGenerator->generate());
+        self::assertStringMatchesFormat('%A) : ' . $expectedReturnSignature . '%w{%A', $methodGenerator->generate());
     }
 
     public function returnTypeHintClasses()
@@ -382,15 +383,20 @@ PHP;
             [IterableHintsClass::class, 'nullableIterableReturnValue', '?iterable'],
             [ObjectHintsClass::class, 'objectReturnValue', 'object'],
             [ObjectHintsClass::class, 'nullableObjectReturnValue', '?object'],
+            [Php80Types::class, 'mixedType', 'mixed'],
+            [Php80Types::class, 'falseType', '\\' . Php80Types::class . '|false'],
+            [Php80Types::class, 'unionNullableType', '?bool'],
+            [Php80Types::class, 'unionReverseNullableType', '?bool'],
+            [Php80Types::class, 'unionNullableTypeWithDefaultValue', 'bool|string|null'],
+            [Php80Types::class, 'unionType', '\\' . Php80Types::class . '|\\' . stdClass::class],
+            [Php80Types::class, 'staticType', 'static'],
         ];
 
         return array_filter(
             $parameters,
             function (array $parameter) {
-                return PHP_VERSION_ID >= 70200
-                    || (
-                        false === strpos($parameter[2], 'object')
-                    );
+                return PHP_VERSION_ID >= 80000
+                    || $parameter[0] !== Php80Types::class;
             }
         );
     }
@@ -421,5 +427,46 @@ PHP;
         );
 
         self::assertStringMatchesFormat('%Apublic function & byRefReturn()%A', $methodGenerator->generate());
+    }
+
+    /**
+     * @requires PHP >= 8.0
+     * @group laminas/laminas-code#53
+     *
+     * @dataProvider php80Methods
+     *
+     * @psalm-param class-string $className
+     * @psalm-param non-empty-string $method
+     * @psalm-param non-empty-string $expectedGeneratedSignature
+     */
+    public function testGeneratedReturnTypeForPhp80ReturnType(
+        string $className,
+        string $method,
+        string $expectedType,
+        string $expectedGeneratedSignature
+    ): void {
+        $generator = MethodGenerator::fromReflection(new MethodReflection($className, $method));
+        $returnType = $generator->getReturnType();
+
+        self::assertNotNull($returnType);
+        self::assertSame($expectedType, $returnType->__toString());
+        self::assertSame($expectedGeneratedSignature, $returnType->generate());
+    }
+
+    /**
+     * @psalm-return non-empty-list<int, class-string, non-empty-string, string, string>
+     */
+    public function php80Methods(): array
+    {
+        return [
+            [Php80Types::class, 'mixedType', 'mixed', 'mixed'],
+            [Php80Types::class, 'falseType', Php80Types::class . '|false', '\\' . Php80Types::class . '|false'],
+            [Php80Types::class, 'unionNullableType', 'bool', '?bool'],
+            [Php80Types::class, 'unionReverseNullableType', 'bool', '?bool'],
+            [Php80Types::class, 'unionNullableTypeWithDefaultValue', 'bool|string|null', 'bool|string|null'],
+            [Php80Types::class, 'unionType', Php80Types::class . '|' . stdClass::class, '\\' . Php80Types::class . '|\\' . stdClass::class],
+            [Php80Types::class, 'staticType', 'static', 'static'],
+            [Php80Types::class, 'selfAndBoolType', Php80Types::class . '|bool', '\\' . Php80Types::class . '|bool'],
+        ];
     }
 }

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -454,7 +454,7 @@ PHP;
     }
 
     /**
-     * @psalm-return non-empty-list<int, class-string, non-empty-string, string, string>
+     * @psalm-return non-empty-list<array{class-string, non-empty-string, non-empty-string, non-empty-string}>
      */
     public function php80Methods(): array
     {

--- a/test/Generator/ParameterGeneratorTest.php
+++ b/test/Generator/ParameterGeneratorTest.php
@@ -591,6 +591,18 @@ class ParameterGeneratorTest extends TestCase
         self::assertSame('null', strtolower((string) $parameter->getDefaultValue()));
     }
 
+    /**
+     * @group laminas/laminas-code#53
+     */
+    public function testGetInternalClassDefaultParameterValueWithUnionType()
+    {
+        $parameter = ParameterGenerator::fromReflection(new ParameterReflection([\Phar::class, 'extractTo'], 1));
+
+        self::assertSame('array|string|null', strtolower((string) $parameter->getType()));
+        self::assertSame('null', strtolower((string) $parameter->getDefaultValue()));
+        self::assertSame('array|string|null $files = null', $parameter->generate());
+    }
+
     public function testOmitType()
     {
         $parameter = new ParameterGenerator('foo', 'string', 'bar');

--- a/test/Generator/ParameterGeneratorTest.php
+++ b/test/Generator/ParameterGeneratorTest.php
@@ -615,7 +615,7 @@ class ParameterGeneratorTest extends TestCase
     }
 
     /**
-     * @psalm-return non-empty-list<int, class-string, non-empty-string, positive-int|0, string, non-empty-string>
+     * @psalm-return non-empty-list<array{class-string, non-empty-string, positive-int|0, string, non-empty-string}>
      */
     public function php80Methods(): array
     {

--- a/test/TestAsset/Php80Types.php
+++ b/test/TestAsset/Php80Types.php
@@ -2,6 +2,8 @@
 
 namespace LaminasTest\Code\TestAsset;
 
+use BadMethodCallException;
+
 /**
  * This test assets contains new types introduced with the PHP 8.0.0 release
  *
@@ -15,42 +17,42 @@ class Php80Types
 {
     public function mixedType(mixed $parameter): mixed
     {
-        return $parameter;
+        throw new BadMethodCallException('Not supposed to be run');
     }
 
     /** Note: the false type cannot be used standalone, and must be part of a union type */
     public function falseType(false|self $parameter): false|self
     {
-        return $parameter;
+        throw new BadMethodCallException('Not supposed to be run');
     }
 
     public function unionNullableType(bool|null $parameter): bool|null
     {
-        return $parameter;
+        throw new BadMethodCallException('Not supposed to be run');
     }
 
     public function unionReverseNullableType(null|bool $parameter): null|bool
     {
-        return $parameter;
+        throw new BadMethodCallException('Not supposed to be run');
     }
 
     public function unionNullableTypeWithDefaultValue(bool|string|null $parameter = null): bool|string|null
     {
-        return $parameter;
+        throw new BadMethodCallException('Not supposed to be run');
     }
 
     public function unionType(Php80Types|\stdClass $parameter): Php80Types|\stdClass
     {
-        return $parameter;
+        throw new BadMethodCallException('Not supposed to be run');
     }
 
     public function staticType(self $parameter): static
     {
-        return $parameter;
+        throw new BadMethodCallException('Not supposed to be run');
     }
 
     public function selfAndBoolType(self|bool $parameter): self|bool
     {
-        return $parameter;
+        throw new BadMethodCallException('Not supposed to be run');
     }
 }

--- a/test/TestAsset/Php80Types.php
+++ b/test/TestAsset/Php80Types.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace LaminasTest\Code\TestAsset;
+
+/**
+ * This test assets contains new types introduced with the PHP 8.0.0 release
+ *
+ * @see https://www.php.net/ChangeLog-8.php#PHP_8_0
+ * @see https://wiki.php.net/rfc/union_types_v2
+ * @see https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.union
+ * @see https://wiki.php.net/rfc/static_return_type
+ * @see https://wiki.php.net/rfc/mixed_type_v2
+ */
+class Php80Types
+{
+    public function mixedType(mixed $parameter): mixed
+    {
+        return $parameter;
+    }
+
+    /** Note: the false type cannot be used standalone, and must be part of a union type */
+    public function falseType(false|self $parameter): false|self
+    {
+        return $parameter;
+    }
+
+    public function unionNullableType(bool|null $parameter): bool|null
+    {
+        return $parameter;
+    }
+
+    public function unionReverseNullableType(null|bool $parameter): null|bool
+    {
+        return $parameter;
+    }
+
+    public function unionNullableTypeWithDefaultValue(bool|string|null $parameter = null): bool|string|null
+    {
+        return $parameter;
+    }
+
+    public function unionType(Php80Types|\stdClass $parameter): Php80Types|\stdClass
+    {
+        return $parameter;
+    }
+
+    public function staticType(self $parameter): static
+    {
+        return $parameter;
+    }
+
+    public function selfAndBoolType(self|bool $parameter): self|bool
+    {
+        return $parameter;
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This is an overhaul of #53 by @fezfez which does:

 1. bump the minimum required PHP version to 7.4 (7.3 support ends this week)
 2. add extensive tests and improvements to `TypeGenerator` to accept various formats of PHP-8.0 type-related features (`mixed`, `false`, `null`, union)

Fixes #53
Fixes #54