### PR TITLE
Feature - #62 upgrade coding standard and lock dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.phpunit.result.cache
 /clover.xml
-/composer.lock
 /coveralls-upload.json
 /docs/html/
 /laminas-mkdoc-theme.tgz

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,11 @@
     "require-dev": {
         "ext-phar": "*",
         "doctrine/annotations": "^1.10.4",
-        "laminas/laminas-coding-standard": "^1.0.0",
+        "laminas/laminas-coding-standard": "^2.1.4",
         "laminas/laminas-stdlib": "^3.3.0",
         "phpunit/phpunit": "^9.4.2",
-        "psalm/plugin-phpunit": "^0.13.0",
-        "vimeo/psalm": "^4.2"
+        "psalm/plugin-phpunit": "^0.14.0",
+        "vimeo/psalm": "^4.3.1"
     },
     "conflict": {
         "phpspec/prophecy": "<1.9.0"

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,4407 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "2fb9c06f414decb3542601521e351397",
+    "packages": [
+        {
+            "name": "laminas/laminas-eventmanager",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-eventmanager.git",
+                "reference": "1940ccf30e058b2fd66f5a9d696f1b5e0027b082"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/1940ccf30e058b2fd66f5a9d696f1b5e0027b082",
+                "reference": "1940ccf30e058b2fd66f5a9d696f1b5e0027b082",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^7.3 || ^8.0"
+            },
+            "replace": {
+                "zendframework/zend-eventmanager": "^3.2.1"
+            },
+            "require-dev": {
+                "container-interop/container-interop": "^1.1",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0",
+                "phpbench/phpbench": "^0.17.1",
+                "phpunit/phpunit": "^8.5.8"
+            },
+            "suggest": {
+                "container-interop/container-interop": "^1.1, to use the lazy listeners feature",
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3.x-dev",
+                    "dev-develop": "3.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-eventmanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-eventmanager/issues",
+                "rss": "https://github.com/laminas/laminas-eventmanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-eventmanager"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-08-25T11:10:44+00:00"
+        },
+        {
+            "name": "laminas/laminas-zendframework-bridge",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
+                "reference": "6ede70583e101030bcace4dcddd648f760ddf642"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6ede70583e101030bcace4dcddd648f760ddf642",
+                "reference": "6ede70583e101030bcace4dcddd648f760ddf642",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1 || ^9.3",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ZendFrameworkBridge"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ZendFrameworkBridge\\": "src//"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
+            "keywords": [
+                "ZendFramework",
+                "autoloading",
+                "laminas",
+                "zf"
+            ],
+            "support": {
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
+                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
+                "source": "https://github.com/laminas/laminas-zendframework-bridge"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-09-14T14:23:00+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "amphp/amp",
+            "version": "v2.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "ecdc3c476b3ccff02f8e5d5bcc04f7ccfd18751c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/ecdc3c476b3ccff02f8e5d5bcc04f7ccfd18751c",
+                "reference": "ecdc3c476b3ccff02f8e5d5bcc04f7ccfd18751c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1",
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6.0.9 | ^7",
+                "psalm/phar": "^3.11@dev",
+                "react/promise": "^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php",
+                    "lib/Internal/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "http://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/v2.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-03T16:23:45+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "f0c20cf598a958ba2aa8c6e5a71c697d652c7088"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/f0c20cf598a958ba2aa8c6e5a71c697d652c7088",
+                "reference": "f0c20cf598a958ba2aa8c6e5a71c697d652c7088",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1.4",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6 || ^7 || ^8",
+                "psalm/phar": "^3.11.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\ByteStream\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "http://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/byte-stream/issues",
+                "source": "https://github.com/amphp/byte-stream/tree/master"
+            },
+            "time": "2020-06-29T18:35:05+00:00"
+        },
+        {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.11.99.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "7413f0b55a051e89485c5cb9f765fe24bb02a7b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/7413f0b55a051e89485c5cb9f765fe24bb02a7b6",
+                "reference": "7413f0b55a051e89485c5cb9f765fe24bb02a7b6",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7 || ^8"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.11.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/composer/package-versions-deprecated/issues",
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.1"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-11T10:22:58+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
+                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.54",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.2.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T08:59:24+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "1.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f28d44c286812c714741478d968104c5e604a1d4",
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/1.4.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T08:04:11+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
+        },
+        {
+            "name": "dnoegel/php-xdg-base-dir",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.0|~6.0|~5.0|~4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "XdgBaseDir\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "implementation of xdg base directory specification for php",
+            "support": {
+                "issues": "https://github.com/dnoegel/php-xdg-base-dir/issues",
+                "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
+            },
+            "time": "2019-12-04T15:06:13+00:00"
+        },
+        {
+            "name": "doctrine/annotations",
+            "version": "1.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
+                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "ext-tokenizer": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "doctrine/coding-standard": "^6.0 || ^8.1",
+                "phpstan/phpstan": "^0.12.20",
+                "phpunit/phpunit": "^7.5 || ^9.1.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/1.11.1"
+            },
+            "time": "2020-10-26T10:28:16+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^8.0",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-10T18:47:58+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/e864bbf5904cb8f5bb334f99209b48018522f042",
+                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/lexer/issues",
+                "source": "https://github.com/doctrine/lexer/tree/1.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-25T17:44:05+00:00"
+        },
+        {
+            "name": "felixfbecker/advanced-json-rpc",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
+                "reference": "0ed363f8de17d284d479ec813c9ad3f6834b5c40"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/0ed363f8de17d284d479ec813c9ad3f6834b5c40",
+                "reference": "0ed363f8de17d284d479ec813c9ad3f6834b5c40",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0 || ^2.0",
+                "php": ">=7.0",
+                "phpdocumentor/reflection-docblock": "^4.0.0 || ^5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
+                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/master"
+            },
+            "time": "2020-03-11T15:21:41+00:00"
+        },
+        {
+            "name": "felixfbecker/language-server-protocol",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
+                "reference": "85e83cacd2ed573238678c6875f8f0d7ec699541"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/85e83cacd2ed573238678c6875f8f0d7ec699541",
+                "reference": "85e83cacd2ed573238678c6875f8f0d7ec699541",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "*",
+                "squizlabs/php_codesniffer": "^3.1",
+                "vimeo/psalm": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LanguageServerProtocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "PHP classes for the Language Server Protocol",
+            "keywords": [
+                "language",
+                "microsoft",
+                "php",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.0"
+            },
+            "time": "2020-10-23T13:55:30+00:00"
+        },
+        {
+            "name": "laminas/laminas-coding-standard",
+            "version": "2.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-coding-standard.git",
+                "reference": "d75f1acf615232e108da2d2cf5a7df3e527b8f38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/d75f1acf615232e108da2d2cf5a7df3e527b8f38",
+                "reference": "d75f1acf615232e108da2d2cf5a7df3e527b8f38",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^7.3 || ~8.0.0",
+                "slevomat/coding-standard": "^6.4.1",
+                "squizlabs/php_codesniffer": "^3.5.8",
+                "webimpress/coding-standard": "^1.1.6"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Laminas Coding Standard",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "Coding Standard",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-coding-standard/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-coding-standard/issues",
+                "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
+                "source": "https://github.com/laminas/laminas-coding-standard"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-10-26T07:33:05+00:00"
+        },
+        {
+            "name": "laminas/laminas-stdlib",
+            "version": "3.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-stdlib.git",
+                "reference": "d81c7ffe602ed0e6ecb18691019111c0f4bf1efe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/d81c7ffe602ed0e6ecb18691019111c0f4bf1efe",
+                "reference": "d81c7ffe602ed0e6ecb18691019111c0f4bf1efe",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^7.3 || ^8.0"
+            },
+            "replace": {
+                "zendframework/zend-stdlib": "^3.2.1"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "phpbench/phpbench": "^0.17.1",
+                "phpunit/phpunit": "~9.3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "SPL extensions, array utilities, error handlers, and more",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "stdlib"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-stdlib/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-stdlib/issues",
+                "rss": "https://github.com/laminas/laminas-stdlib/releases.atom",
+                "source": "https://github.com/laminas/laminas-stdlib"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-11-19T20:18:59+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T09:40:50+00:00"
+        },
+        {
+            "name": "netresearch/jsonmapper",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/e0f1e33a71587aca81be5cffbb9746510e1fe04e",
+                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4 || ~7.0",
+                "squizlabs/php_codesniffer": "~3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "support": {
+                "email": "cweiske@cweiske.de",
+                "issues": "https://github.com/cweiske/jsonmapper/issues",
+                "source": "https://github.com/cweiske/jsonmapper/tree/master"
+            },
+            "time": "2020-04-16T18:48:43+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.10.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984",
+                "reference": "dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.3"
+            },
+            "time": "2020-12-03T17:45:45+00:00"
+        },
+        {
+            "name": "openlss/lib-array2xml",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nullivex/lib-array2xml.git",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LSS": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Tong",
+                    "email": "bryan@nullivex.com",
+                    "homepage": "https://www.nullivex.com"
+                },
+                {
+                    "name": "Tony Butler",
+                    "email": "spudz76@gmail.com",
+                    "homepage": "https://www.nullivex.com"
+                }
+            ],
+            "description": "Array2XML conversion library credit to lalit.org",
+            "homepage": "https://www.nullivex.com",
+            "keywords": [
+                "array",
+                "array conversion",
+                "xml",
+                "xml conversion"
+            ],
+            "support": {
+                "issues": "https://github.com/nullivex/lib-array2xml/issues",
+                "source": "https://github.com/nullivex/lib-array2xml/tree/master"
+            },
+            "time": "2019-03-29T20:06:56+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/master"
+            },
+            "time": "2020-06-27T14:33:11+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "726c026815142e4f8677b7cb7f2249c9ffb7ecae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/726c026815142e4f8677b7cb7f2249c9ffb7ecae",
+                "reference": "726c026815142e4f8677b7cb7f2249c9ffb7ecae",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.0.3"
+            },
+            "time": "2020-11-30T09:21:21+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.3",
+                "webmozart/assert": "^1.9.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+            },
+            "time": "2020-09-03T19:13:55+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+            },
+            "time": "2020-09-17T18:55:26+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "1.12.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/8ce87516be71aae9b956f81906aaf0338e0d8a2d",
+                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.2",
+                "php": "^7.2 || ~8.0, <8.1",
+                "phpdocumentor/reflection-docblock": "^5.2",
+                "sebastian/comparator": "^3.0 || ^4.0",
+                "sebastian/recursion-context": "^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^6.0",
+                "phpunit/phpunit": "^8.0 || ^9.0 <9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/1.12.1"
+            },
+            "time": "2020-09-29T09:10:42+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "0.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.5",
+                "ergebnis/composer-normalize": "^2.0.2",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "phing/phing": "^2.16.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.26",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^6.3",
+                "slevomat/coding-standard": "^4.7.2",
+                "symfony/process": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/master"
+            },
+            "time": "2020-08-03T20:32:43+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f3e026641cc91909d421802dd3ac7827ebfd97e1",
+                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.10.2",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0.3",
+                "sebastian/version": "^3.0.1",
+                "theseer/tokenizer": "^1.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-28T06:44:49+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/aa4be8575f26070b100fccb67faabb28f21f66f8",
+                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:57:25+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "8e16c225d57c3d6808014df6b1dd7598d0a5bbbe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8e16c225d57c3d6808014df6b1dd7598d0a5bbbe",
+                "reference": "8e16c225d57c3d6808014df6b1dd7598d0a5bbbe",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.3.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.1",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.3",
+                "phpspec/prophecy": "^1.12.1",
+                "phpunit/php-code-coverage": "^9.2.3",
+                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.3",
+                "phpunit/php-timer": "^5.0.2",
+                "sebastian/cli-parser": "^1.0.1",
+                "sebastian/code-unit": "^1.0.6",
+                "sebastian/comparator": "^4.0.5",
+                "sebastian/diff": "^4.0.3",
+                "sebastian/environment": "^5.1.3",
+                "sebastian/exporter": "^4.0.3",
+                "sebastian/global-state": "^5.0.1",
+                "sebastian/object-enumerator": "^4.0.3",
+                "sebastian/resource-operations": "^3.0.3",
+                "sebastian/type": "^2.3",
+                "sebastian/version": "^3.0.2"
+            },
+            "require-dev": {
+                "ext-pdo": "*",
+                "phpspec/prophecy-phpunit": "^2.0.1"
+            },
+            "suggest": {
+                "ext-soap": "*",
+                "ext-xdebug": "*"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.5-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ],
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/donate.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-12-04T05:05:53+00:00"
+        },
+        {
+            "name": "psalm/plugin-phpunit",
+            "version": "0.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
+                "reference": "f5147be764449ff5a11bded483b622e1e868f8ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/f5147be764449ff5a11bded483b622e1e868f8ab",
+                "reference": "f5147be764449ff5a11bded483b622e1e868f8ab",
+                "shasum": ""
+            },
+            "require": {
+                "composer/package-versions-deprecated": "^1.10",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "ext-simplexml": "*",
+                "php": "^7.1 || ^8.0",
+                "vimeo/psalm": "dev-master || dev-4.x || ^4.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.5"
+            },
+            "require-dev": {
+                "codeception/codeception": "^4.0.3",
+                "php": "^7.3 || ^8.0",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.3.1",
+                "weirdan/codeception-psalm-module": "^0.11.0",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Psalm\\PhpUnitPlugin\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\PhpUnitPlugin\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Brown",
+                    "email": "github@muglug.com"
+                }
+            ],
+            "description": "Psalm plugin for PHPUnit",
+            "support": {
+                "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.14.0"
+            },
+            "time": "2020-12-08T22:25:25+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/master"
+            },
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.3"
+            },
+            "time": "2020-03-23T09:12:05+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:08:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:49:45+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.7",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:52:27+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:10:38+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/388b6ced16caa751030f6a69e588299fa09200ac",
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:52:38+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:24:23+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/a90ccbddffa067b51f574dea6eb25d5680839455",
+                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:55:19+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.6",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-28T06:42:11+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:17:30+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:45:17+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
+                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:18:59+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "6.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/696dcca217d0c9da2c40d02731526c1e25b65346",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpdoc-parser": "0.4.5 - 0.4.9",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "phing/phing": "2.16.3",
+                "php-parallel-lint/php-parallel-lint": "1.2.0",
+                "phpstan/phpstan": "0.12.48",
+                "phpstan/phpstan-deprecation-rules": "0.12.5",
+                "phpstan/phpstan-phpunit": "0.12.16",
+                "phpstan/phpstan-strict-rules": "0.12.5",
+                "phpunit/phpunit": "7.5.20|8.5.5|9.4.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/6.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-05T12:39:37+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2020-10-23T02:01:07+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v5.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "3e0564fb08d44a98bd5f1960204c958e57bd586b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3e0564fb08d44a98bd5f1960204c958e57bd586b",
+                "reference": "3e0564fb08d44a98bd5f1960204c958e57bd586b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/string": "^5.1"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<4.4",
+                "symfony/dotenv": "<5.1",
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<4.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/event-dispatcher": "^4.4|^5.0",
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v5.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-28T11:24:18+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.20-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "c7cf3f858ec7d70b89559d6e6eb1f7c2517d479c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/c7cf3f858ec7d70b89559d6e6eb1f7c2517d479c",
+                "reference": "c7cf3f858ec7d70b89559d6e6eb1f7c2517d479c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.20-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "727d1096295d807c309fb01a851577302394c897"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/727d1096295d807c309fb01a851577302394c897",
+                "reference": "727d1096295d807c309fb01a851577302394c897",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.20-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/39d483bdf39be819deabf04ec872eb0b2410b531",
+                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.20-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "8ff431c517be11c78c48a39a66d37431e26a6bed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/8ff431c517be11c78c48a39a66d37431e26a6bed",
+                "reference": "8ff431c517be11c78c48a39a66d37431e26a6bed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.20-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
+                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.20-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-07T11:33:47+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v5.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "40e975edadd4e32cd16f3753b3bad65d9ac48242"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/40e975edadd4e32cd16f3753b3bad65d9ac48242",
+                "reference": "40e975edadd4e32cd16f3753b3bad65d9ac48242",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "~1.15"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/http-client": "^4.4|^5.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "symfony/var-exporter": "^4.4|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony String component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v5.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T12:08:07+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-07-12T23:59:07+00:00"
+        },
+        {
+            "name": "vimeo/psalm",
+            "version": "4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vimeo/psalm.git",
+                "reference": "2feba22a005a18bf31d4c7b9bdb9252c73897476"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/2feba22a005a18bf31d4c7b9bdb9252c73897476",
+                "reference": "2feba22a005a18bf31d4c7b9bdb9252c73897476",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2.1",
+                "amphp/byte-stream": "^1.5",
+                "composer/package-versions-deprecated": "^1.8.0",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "composer/xdebug-handler": "^1.1",
+                "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "felixfbecker/advanced-json-rpc": "^3.0.3",
+                "felixfbecker/language-server-protocol": "^1.4",
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0",
+                "nikic/php-parser": "^4.10.1",
+                "openlss/lib-array2xml": "^1.0",
+                "php": "^7.1|^8",
+                "sebastian/diff": "^3.0 || ^4.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "webmozart/path-util": "^2.3"
+            },
+            "provide": {
+                "psalm/psalm": "self.version"
+            },
+            "require-dev": {
+                "amphp/amp": "^2.4.2",
+                "bamarni/composer-bin-plugin": "^1.2",
+                "brianium/paratest": "^4.0.0",
+                "ext-curl": "*",
+                "php": "^7.3|^8",
+                "phpdocumentor/reflection-docblock": "^5",
+                "phpmyadmin/sql-parser": "5.1.0",
+                "phpspec/prophecy": ">=1.9.0",
+                "phpunit/phpunit": "^9.0",
+                "psalm/plugin-phpunit": "^0.13",
+                "slevomat/coding-standard": "^5.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.3",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "suggest": {
+                "ext-igbinary": "^2.0.5"
+            },
+            "bin": [
+                "psalm",
+                "psalm-language-server",
+                "psalm-plugin",
+                "psalm-refactor",
+                "psalter"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\": "src/Psalm/"
+                },
+                "files": [
+                    "src/functions.php",
+                    "src/spl_object_id.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Brown"
+                }
+            ],
+            "description": "A static analysis tool for finding errors in PHP applications",
+            "keywords": [
+                "code",
+                "inspection",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/vimeo/psalm/issues",
+                "source": "https://github.com/vimeo/psalm/tree/4.3.1"
+            },
+            "time": "2020-12-03T16:44:10+00:00"
+        },
+        {
+            "name": "webimpress/coding-standard",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "579818b431e2a2c8f24b60776598499782727897"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/579818b431e2a2c8f24b60776598499782727897",
+                "reference": "579818b431e2a2c8f24b60776598499782727897",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.5.8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.4.3"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.2.x-dev",
+                "dev-develop": "1.3.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-27T20:16:01+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<3.9.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozart/assert/issues",
+                "source": "https://github.com/webmozart/assert/tree/master"
+            },
+            "time": "2020-07-08T17:02:28+00:00"
+        },
+        {
+            "name": "webmozart/path-util",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/path-util.git",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "webmozart/assert": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\PathUtil\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "support": {
+                "issues": "https://github.com/webmozart/path-util/issues",
+                "source": "https://github.com/webmozart/path-util/tree/2.3.0"
+            },
+            "time": "2015-12-17T08:42:14+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^7.4 || ~8.0.0"
+    },
+    "platform-dev": {
+        "ext-phar": "*"
+    },
+    "plugin-api-version": "2.0.0"
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,10 +1,35 @@
 <?xml version="1.0"?>
-<ruleset name="Laminas coding standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
-
+<ruleset
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd"
+>
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
     <exclude-pattern>*/TestAsset/*</exclude-pattern>
     <exclude-pattern>*/_files/*</exclude-pattern>
+
+    <rule ref="LaminasCodingStandard">
+        <!-- non-strict comparisons are used in a lot of legacy code, and must be removed with care and additional
+             testing. For now, we accept that it exists in the codebase -->
+        <exclude name="SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedEqualOperator"/>
+        <exclude name="SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedNotEqualOperator"/>
+
+        <!-- the `GOTO` statement is used in legacy scanner code that was written in such way in order to achieve
+             better performance in a time at which the PHP engine did not yet have JIT or OpCache optimizations.
+             It could be removed in future, but adapting the code now is a major endeavour that should be taken
+             on with clarity that it requires a lot of effort to do so. -->
+        <exclude name="Generic.PHP.DiscourageGoto.Found"/>
+
+        <!-- As a result of using `GOTO`, some code is incorrectly detected as "unreachable" by phpcs -->
+        <exclude name="Squiz.PHP.NonExecutableCode.Unreachable"/>
+
+        <!-- Variables in scanner code do not respect standard naming conventions due to parser logic following
+             more traditional lexeme/token uppercase naming -->
+        <exclude name="WebimpressCodingStandard.NamingConventions.ValidVariableName.NotCamelCaps"/>
+
+        <!-- sometimes, the reference and bitwise `&` are confused by coding standard rules, and that can lead
+             to mis-interpretation of spacing rules -->
+        <exclude name="WebimpressCodingStandard.Formatting.Reference.UnexpectedSpace"/>
+    </rule>
 </ruleset>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.3.1@2feba22a005a18bf31d4c7b9bdb9252c73897476">
   <file src="src/DeclareStatement.php">
-    <MissingParamType occurrences="1">
-      <code>$value</code>
-    </MissingParamType>
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$directive</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="2">
-      <code>$this-&gt;value</code>
+    <MixedAssignment occurrences="1">
       <code>$value</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
@@ -103,15 +99,13 @@
       <code>self::FLAG_FINAL</code>
       <code>self::FLAG_FINAL</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="4">
+    <MissingReturnType occurrences="3">
       <code>addTraitAlias</code>
       <code>addTraitOverride</code>
-      <code>generate</code>
       <code>removeTrait</code>
     </MissingReturnType>
-    <MixedArgument occurrences="13">
+    <MixedArgument occurrences="12">
       <code>$array['name']</code>
-      <code>$this-&gt;traitUsageGenerator-&gt;generate()</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
@@ -306,14 +300,6 @@
       <code>VarTag</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="src/Generator/DocBlock/TagManager.php">
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$newTag</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
-      <code>TagInterface</code>
-    </MoreSpecificReturnType>
-  </file>
   <file src="src/Generator/DocBlockGenerator.php">
     <DeprecatedClass occurrences="1">
       <code>new Tag()</code>
@@ -353,9 +339,6 @@
       <code>null !== ($ld = $this-&gt;getLongDescription())</code>
       <code>null !== ($sd = $this-&gt;getShortDescription())</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedInterfaceMethod occurrences="1">
-      <code>generate</code>
-    </UndefinedInterfaceMethod>
     <UnsafeInstantiation occurrences="2">
       <code>new static()</code>
       <code>new static()</code>
@@ -369,22 +352,16 @@
     <InvalidArgument occurrences="1">
       <code>$docBlock</code>
     </InvalidArgument>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$uses</code>
+    </LessSpecificReturnStatement>
     <MissingClosureParamType occurrences="1">
       <code>$value</code>
     </MissingClosureParamType>
-    <MissingReturnType occurrences="1">
-      <code>setDeclares</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="14">
-      <code>$alias</code>
+    <MixedArgument occurrences="8">
       <code>$alias</code>
       <code>$class</code>
-      <code>$class-&gt;generate()</code>
       <code>$import</code>
-      <code>$import</code>
-      <code>$import</code>
-      <code>$uses[$useIndex][0]</code>
-      <code>$uses[$useIndex][0]</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
@@ -395,52 +372,21 @@
       <code>$name</code>
       <code>$name</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="6">
+    <MixedAssignment occurrences="7">
       <code>$alias</code>
-      <code>$import</code>
-      <code>$uses[$useIndex][0]</code>
-      <code>$uses[$useIndex][0]</code>
-      <code>$uses[$useIndex][0]</code>
-      <code>$uses[$useIndex][1]</code>
-    </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="3">
-      <code>$uses[$useIndex][2]</code>
-      <code>$uses[$useIndex][2]</code>
-      <code>$uses[$useIndex][2]</code>
-    </MixedArrayAssignment>
-    <MixedAssignment occurrences="13">
-      <code>$alias</code>
-      <code>$class</code>
-      <code>$class</code>
       <code>$class</code>
       <code>$import</code>
       <code>$import</code>
       <code>$requiredFile</code>
       <code>$use</code>
-      <code>$use</code>
-      <code>$uses[$useIndex][2]</code>
-      <code>$uses[$useIndex][2]</code>
       <code>$value</code>
-      <code>list($import, $alias)</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>ClassGenerator</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall occurrences="1">
-      <code>isSourceDirty</code>
-    </MixedMethodCall>
-    <MixedOperand occurrences="2">
-      <code>$class-&gt;generate()</code>
+    <MixedOperand occurrences="1">
       <code>$requiredFile</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="2">
-      <code>$class</code>
-      <code>$this-&gt;classes[(string)$name]</code>
-    </MixedReturnStatement>
-    <MixedReturnTypeCoercion occurrences="2">
-      <code>$this-&gt;classes</code>
-      <code>ClassGenerator[]</code>
-    </MixedReturnTypeCoercion>
+    <MoreSpecificReturnType occurrences="1">
+      <code>array&lt;int, array{string, null|string, false|null|string}&gt;</code>
+    </MoreSpecificReturnType>
     <NullArgument occurrences="1">
       <code>null</code>
     </NullArgument>
@@ -451,11 +397,10 @@
       <code>$namespace</code>
       <code>FileGenerator</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="4">
+    <RedundantCastGivenDocblockType occurrences="3">
       <code>(string) $body</code>
       <code>(string) $filename</code>
       <code>(string) $namespace</code>
-      <code>(string)$name</code>
     </RedundantCastGivenDocblockType>
     <RedundantConditionGivenDocblockType occurrences="4">
       <code>! empty($uses) &amp;&amp; is_array($uses)</code>
@@ -466,11 +411,6 @@
     <UnsafeInstantiation occurrences="1">
       <code>new static()</code>
     </UnsafeInstantiation>
-  </file>
-  <file src="src/Generator/GeneratorInterface.php">
-    <MissingReturnType occurrences="1">
-      <code>generate</code>
-    </MissingReturnType>
   </file>
   <file src="src/Generator/InterfaceGenerator.php">
     <MissingParamType occurrences="1">
@@ -683,10 +623,9 @@
     <DocblockTypeContradiction occurrences="1">
       <code>is_string($alias)</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="4">
+    <MissingReturnType occurrences="3">
       <code>addTraitAlias</code>
       <code>addTraitOverride</code>
-      <code>generate</code>
       <code>removeTrait</code>
     </MissingReturnType>
     <MixedArgument occurrences="16">
@@ -814,21 +753,14 @@
       <code>$n</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="5">
       <code>$constant</code>
       <code>$curValue</code>
       <code>$n</code>
-      <code>$outputParts[]</code>
-      <code>$partV</code>
       <code>$v</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="2">
-      <code>generate</code>
-      <code>setArrayDepth</code>
-    </MixedMethodCall>
-    <MixedOperand occurrences="2">
-      <code>$partV</code>
+    <MixedOperand occurrences="1">
       <code>$value</code>
     </MixedOperand>
     <PropertyNotSetInConstructor occurrences="2">
@@ -939,28 +871,12 @@
       <code>$description</code>
       <code>$methodName</code>
     </MissingConstructor>
-    <MixedInferredReturnType occurrences="1">
-      <code>null|string</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;types[0]</code>
-    </MixedReturnStatement>
-    <MixedReturnTypeCoercion occurrences="2">
-      <code>$this-&gt;types</code>
-      <code>getTypes</code>
-    </MixedReturnTypeCoercion>
   </file>
   <file src="src/Reflection/DocBlock/Tag/ParamTag.php">
     <MissingConstructor occurrences="2">
       <code>$description</code>
       <code>$variableName</code>
     </MissingConstructor>
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;types[0]</code>
-    </MixedReturnStatement>
     <MixedReturnTypeCoercion occurrences="2">
       <code>$this-&gt;types</code>
       <code>getTypes</code>
@@ -971,16 +887,6 @@
       <code>$description</code>
       <code>$propertyName</code>
     </MissingConstructor>
-    <MixedInferredReturnType occurrences="1">
-      <code>null|string</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;types[0]</code>
-    </MixedReturnStatement>
-    <MixedReturnTypeCoercion occurrences="2">
-      <code>$this-&gt;types</code>
-      <code>getTypes</code>
-    </MixedReturnTypeCoercion>
   </file>
   <file src="src/Reflection/DocBlock/Tag/ReturnTag.php">
     <MissingConstructor occurrences="1">
@@ -998,23 +904,9 @@
     </MixedReturnTypeCoercion>
   </file>
   <file src="src/Reflection/DocBlock/Tag/ThrowsTag.php">
-    <LessSpecificImplementedReturnType occurrences="1">
-      <code>array</code>
-    </LessSpecificImplementedReturnType>
     <MissingConstructor occurrences="1">
       <code>$description</code>
     </MissingConstructor>
-  </file>
-  <file src="src/Reflection/DocBlock/TagManager.php">
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$newTag</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
-      <code>TagInterface</code>
-    </MoreSpecificReturnType>
-    <UndefinedInterfaceMethod occurrences="1">
-      <code>initialize</code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="src/Reflection/DocBlockReflection.php">
     <DocblockTypeContradiction occurrences="1">
@@ -1307,7 +1199,7 @@
   </file>
   <file src="test/Generator/AbstractMemberGeneratorTest.php">
     <InvalidArgument occurrences="1">
-      <code>new \stdClass()</code>
+      <code>new stdClass()</code>
     </InvalidArgument>
     <MissingReturnType occurrences="2">
       <code>testSetDocBlockThrowsExceptionWithInvalidType</code>
@@ -1328,7 +1220,7 @@
       <code>ExceptionInterface::class</code>
       <code>[]</code>
       <code>new ClassGenerator()</code>
-      <code>new \stdClass()</code>
+      <code>new stdClass()</code>
     </InvalidArgument>
     <InvalidScalarArgument occurrences="5">
       <code>'public'</code>
@@ -1434,34 +1326,11 @@
       <code>testTraitGenerationWithAliasesAndOverrides</code>
       <code>testUseTraitGeneration</code>
     </MissingReturnType>
-    <MixedArgument occurrences="29">
-      <code>$classGenerator-&gt;generate()</code>
-      <code>$classGenerator-&gt;generate()</code>
-      <code>$classGenerator-&gt;generate()</code>
-      <code>$classGenerator-&gt;generate()</code>
-      <code>$classGenerator-&gt;generate()</code>
-      <code>$classGenerator-&gt;generate()</code>
-      <code>$code</code>
-      <code>$code</code>
-      <code>$code</code>
-      <code>$generated</code>
-      <code>$generated</code>
-      <code>$generated</code>
-      <code>$generated</code>
-      <code>$generated</code>
-      <code>$generated</code>
-      <code>$generated</code>
-      <code>$output</code>
-      <code>$output</code>
+    <MixedArgument occurrences="6">
       <code>$overrides['myTrait::foo']</code>
       <code>$overrides['myTrait::foo']</code>
       <code>$overrides['myTrait::foo']</code>
       <code>$overrides['myTrait::foo']</code>
-      <code>$received</code>
-      <code>$received</code>
-      <code>$received</code>
-      <code>$received</code>
-      <code>$received</code>
       <code>FooClass::class</code>
       <code>FooClass::class</code>
     </MixedArgument>
@@ -1474,24 +1343,6 @@
       <code>$overrides['myTrait::foo'][1]</code>
       <code>$overrides['myTrait::foo'][1]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="16">
-      <code>$code</code>
-      <code>$code</code>
-      <code>$code</code>
-      <code>$generated</code>
-      <code>$generated</code>
-      <code>$generated</code>
-      <code>$generated</code>
-      <code>$generated</code>
-      <code>$generated</code>
-      <code>$generated</code>
-      <code>$output</code>
-      <code>$output</code>
-      <code>$output</code>
-      <code>$received</code>
-      <code>$received</code>
-      <code>$received</code>
-    </MixedAssignment>
     <PossiblyFalseReference occurrences="15">
       <code>getDefaultValue</code>
       <code>getDefaultValue</code>
@@ -1727,21 +1578,6 @@
       <code>testSetextendedclassShouldNotIgnoreNonEmptyClassnameOnGenerate</code>
       <code>testToString</code>
     </MissingReturnType>
-    <MixedArgument occurrences="5">
-      <code>$received</code>
-      <code>$received</code>
-      <code>$received</code>
-      <code>$received</code>
-      <code>$received</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="6">
-      <code>$output</code>
-      <code>$output</code>
-      <code>$output</code>
-      <code>$received</code>
-      <code>$received</code>
-      <code>$received</code>
-    </MixedAssignment>
     <PossiblyFalseReference occurrences="2">
       <code>isInterface</code>
       <code>isInterface</code>
@@ -1757,12 +1593,7 @@
     <InvalidArgument occurrences="1">
       <code>new stdClass()</code>
     </InvalidArgument>
-    <MissingDocblockType occurrences="2">
-      <code>$baz</code>
-      <code>$foo</code>
-    </MissingDocblockType>
-    <MissingReturnType occurrences="21">
-      <code>returnTypeHintClasses</code>
+    <MissingReturnType occurrences="20">
       <code>testByRefReturnType</code>
       <code>testCopyMethodSignature</code>
       <code>testCreateFromArray</code>
@@ -1797,8 +1628,7 @@
     <InvalidReturnType occurrences="1">
       <code>string[][]</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="27">
-      <code>dataFromReflectionGenerate</code>
+    <MissingReturnType occurrences="26">
       <code>testCallableTypeHint</code>
       <code>testCreateFromArray</code>
       <code>testDefaultValueGetterAndSetterPersistValue</code>
@@ -1833,7 +1663,7 @@
   <file src="test/Generator/PropertyGeneratorTest.php">
     <InvalidArgument occurrences="2">
       <code>[PropertyGenerator::FLAG_CONSTANT, $flag]</code>
-      <code>new \stdClass()</code>
+      <code>new stdClass()</code>
     </InvalidArgument>
     <InvalidReturnStatement occurrences="1"/>
     <InvalidReturnType occurrences="1">
@@ -1950,9 +1780,6 @@
     </InvalidReturnType>
   </file>
   <file src="test/Generator/TestAsset/TypeableTag.php">
-    <MissingReturnType occurrences="1">
-      <code>generate</code>
-    </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="2">
       <code>TypeableTag</code>
       <code>TypeableTag</code>
@@ -2005,33 +1832,6 @@
       <code>testSetextendedclassShouldNotIgnoreNonEmptyClassnameOnGenerate</code>
       <code>testToString</code>
     </MissingReturnType>
-    <MixedArgument occurrences="12">
-      <code>$code</code>
-      <code>$code</code>
-      <code>$code</code>
-      <code>$generated</code>
-      <code>$generated</code>
-      <code>$generated</code>
-      <code>$output</code>
-      <code>$received</code>
-      <code>$received</code>
-      <code>$received</code>
-      <code>$received</code>
-      <code>$received</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="11">
-      <code>$code</code>
-      <code>$code</code>
-      <code>$code</code>
-      <code>$generated</code>
-      <code>$generated</code>
-      <code>$generated</code>
-      <code>$output</code>
-      <code>$output</code>
-      <code>$received</code>
-      <code>$received</code>
-      <code>$received</code>
-    </MixedAssignment>
   </file>
   <file src="test/Generator/TypeGeneratorTest.php">
     <MissingReturnType occurrences="4">
@@ -2048,12 +1848,8 @@
     <InvalidArgument occurrences="1">
       <code>$constants</code>
     </InvalidArgument>
-    <MissingReturnType occurrences="14">
-      <code>constantsType</code>
-      <code>testAllowedPossibleConstantsType</code>
-      <code>testDefaultInstance</code>
+    <MissingReturnType occurrences="9">
       <code>testEscaping</code>
-      <code>testInvalidConstantsType</code>
       <code>testPropertyDefaultValueCanHandleArray</code>
       <code>testPropertyDefaultValueCanHandleArrayWithUnsortedKeys</code>
       <code>testPropertyDefaultValueCanHandleBool</code>
@@ -2062,11 +1858,9 @@
       <code>testPropertyDefaultValueCanHandleUnquotedString</code>
       <code>testPropertyDefaultValueConstructor</code>
       <code>testPropertyDefaultValueIsSettable</code>
-      <code>testValidConstantTypes</code>
     </MissingReturnType>
-    <MixedInferredReturnType occurrences="6">
+    <MixedInferredReturnType occurrences="5">
       <code>Generator</code>
-      <code>array</code>
       <code>array</code>
       <code>array</code>
       <code>array</code>
@@ -2339,8 +2133,7 @@
     </MissingReturnType>
   </file>
   <file src="test/Reflection/ParameterReflectionTest.php">
-    <MissingReturnType occurrences="10">
-      <code>paramType</code>
+    <MissingReturnType occurrences="9">
       <code>testCallableTypeHint</code>
       <code>testClassReturn</code>
       <code>testClassReturnNoClassGivenReturnsNull</code>

--- a/src/DeclareStatement.php
+++ b/src/DeclareStatement.php
@@ -4,11 +4,21 @@ namespace Laminas\Code;
 
 use Laminas\Code\Exception\InvalidArgumentException;
 
+use function array_keys;
+use function gettype;
+use function implode;
+use function is_string;
+use function key;
+use function lcfirst;
+use function sprintf;
+use function str_replace;
+use function ucwords;
+
 class DeclareStatement
 {
-    public const TICKS = 'ticks';
+    public const TICKS        = 'ticks';
     public const STRICT_TYPES = 'strict_types';
-    public const ENCODING = 'encoding';
+    public const ENCODING     = 'encoding';
 
     private const ALLOWED = [
         self::TICKS        => 'integer',
@@ -16,25 +26,19 @@ class DeclareStatement
         self::ENCODING     => 'string',
     ];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $directive;
 
-    /**
-     * @var int|string
-     */
+    /** @var int|string */
     protected $value;
 
+    /** @param int|string $value */
     private function __construct(string $directive, $value)
     {
         $this->directive = $directive;
-        $this->value = $value;
+        $this->value     = $value;
     }
 
-    /**
-     * @return string
-     */
     public function getDirective(): string
     {
         return $this->directive;
@@ -48,28 +52,16 @@ class DeclareStatement
         return $this->value;
     }
 
-    /**
-     * @param int $value
-     * @return self
-     */
     public static function ticks(int $value): self
     {
         return new self(self::TICKS, $value);
     }
 
-    /**
-     * @param int $value
-     * @return self
-     */
     public static function strictTypes(int $value): self
     {
         return new self(self::STRICT_TYPES, $value);
     }
 
-    /**
-     * @param string $value
-     * @return self
-     */
     public static function encoding(string $value): self
     {
         return new self(self::ENCODING, $value);
@@ -78,7 +70,7 @@ class DeclareStatement
     public static function fromArray(array $config): self
     {
         $directive = key($config);
-        $value = $config[$directive];
+        $value     = $config[$directive];
 
         if (! isset(self::ALLOWED[$directive])) {
             throw new InvalidArgumentException(
@@ -104,9 +96,6 @@ class DeclareStatement
         return self::{$method}($value);
     }
 
-    /**
-     * @return string
-     */
     public function getStatement(): string
     {
         $value = is_string($this->value) ? '\'' . $this->value . '\'' : $this->value;

--- a/src/Generator/AbstractGenerator.php
+++ b/src/Generator/AbstractGenerator.php
@@ -22,21 +22,15 @@ abstract class AbstractGenerator implements GeneratorInterface
     /**
      * Line feed to use in place of EOL
      */
-    const LINE_FEED = "\n";
+    public const LINE_FEED = "\n";
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $isSourceDirty = true;
 
-    /**
-     * @var int|string 4 spaces by default
-     */
+    /** @var int|string 4 spaces by default */
     protected $indentation = '    ';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $sourceContent;
 
     /**

--- a/src/Generator/AbstractMemberGenerator.php
+++ b/src/Generator/AbstractMemberGenerator.php
@@ -14,39 +14,24 @@ use function sprintf;
 
 abstract class AbstractMemberGenerator extends AbstractGenerator
 {
-    /**#@+
-     * @const int Flags for construction usage
-     */
-    const FLAG_ABSTRACT  = 0x01;
-    const FLAG_FINAL     = 0x02;
-    const FLAG_STATIC    = 0x04;
-    const FLAG_INTERFACE = 0x08;
-    const FLAG_PUBLIC    = 0x10;
-    const FLAG_PROTECTED = 0x20;
-    const FLAG_PRIVATE   = 0x40;
-    /**#@-*/
+    public const FLAG_ABSTRACT        = 0x01;
+    public const FLAG_FINAL           = 0x02;
+    public const FLAG_STATIC          = 0x04;
+    public const FLAG_INTERFACE       = 0x08;
+    public const FLAG_PUBLIC          = 0x10;
+    public const FLAG_PROTECTED       = 0x20;
+    public const FLAG_PRIVATE         = 0x40;
+    public const VISIBILITY_PUBLIC    = 'public';
+    public const VISIBILITY_PROTECTED = 'protected';
+    public const VISIBILITY_PRIVATE   = 'private';
 
-    /**#@+
-     * @param const string
-     */
-    const VISIBILITY_PUBLIC    = 'public';
-    const VISIBILITY_PROTECTED = 'protected';
-    const VISIBILITY_PRIVATE   = 'private';
-    /**#@-*/
-
-    /**
-     * @var DocBlockGenerator|null
-     */
+    /** @var DocBlockGenerator|null */
     protected $docBlock;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $name;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $flags = self::FLAG_PUBLIC;
 
     /**

--- a/src/Generator/BodyGenerator.php
+++ b/src/Generator/BodyGenerator.php
@@ -10,9 +10,7 @@ namespace Laminas\Code\Generator;
 
 class BodyGenerator extends AbstractGenerator
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $content;
 
     /**

--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -14,11 +14,9 @@ use function array_diff;
 use function array_filter;
 use function array_map;
 use function array_pop;
-use function array_search;
 use function array_values;
 use function array_walk;
 use function explode;
-use function get_class;
 use function gettype;
 use function implode;
 use function in_array;
@@ -36,74 +34,51 @@ use function substr;
 
 class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
 {
-    const OBJECT_TYPE = 'class';
-    const IMPLEMENTS_KEYWORD = 'implements';
+    public const OBJECT_TYPE        = 'class';
+    public const IMPLEMENTS_KEYWORD = 'implements';
+    public const FLAG_ABSTRACT      = 0x01;
+    public const FLAG_FINAL         = 0x02;
 
-    const FLAG_ABSTRACT = 0x01;
-    const FLAG_FINAL    = 0x02;
-
-    /**
-     * @var FileGenerator
-     */
+    /** @var FileGenerator */
     protected $containingFileGenerator;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $namespaceName;
 
-    /**
-     * @var DocBlockGenerator
-     */
+    /** @var DocBlockGenerator */
     protected $docBlock;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $name;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $flags = 0x00;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $extendedClass;
 
     /**
      * @var string[] Array of string names
-     *
      * @psalm-var array<class-string>
      */
     protected $implementedInterfaces = [];
 
-    /**
-     * @var PropertyGenerator[] Array of properties
-     */
+    /** @var PropertyGenerator[] */
     protected $properties = [];
 
-    /**
-     * @var PropertyGenerator[] Array of constants
-     */
+    /** @var PropertyGenerator[] */
     protected $constants = [];
 
-    /**
-     * @var MethodGenerator[] Array of methods
-     */
+    /** @var MethodGenerator[] */
     protected $methods = [];
 
-    /**
-     * @var TraitUsageGenerator Object to encapsulate trait usage logic
-     */
+    /** @var TraitUsageGenerator Object to encapsulate trait usage logic */
     protected $traitUsageGenerator;
 
     /**
      * Build a Code Generation Php Object from a Class Reflection
      *
-     * @param  ClassReflection $classReflection
-     * @return self
+     * @return static
      */
     public static function fromReflection(ClassReflection $classReflection)
     {
@@ -123,7 +98,6 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
             $cg->setNamespaceName($classReflection->getNamespaceName());
         }
 
-        /* @var \Laminas\Code\Reflection\ClassReflection $parentClass */
         $parentClass = $classReflection->getParentClass();
         $interfaces  = $classReflection->getInterfaces();
 
@@ -135,7 +109,7 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
 
         $interfaceNames = [];
         foreach ($interfaces as $interface) {
-            /* @var \Laminas\Code\Reflection\ClassReflection $interface */
+            /** @var ClassReflection $interface */
             $interfaceNames[] = $interface->getName();
         }
 
@@ -155,7 +129,7 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
 
         foreach ($classReflection->getConstants() as $name => $value) {
             $constants[] = [
-                'name' => $name,
+                'name'  => $name,
                 'value' => $value,
             ];
         }
@@ -189,7 +163,6 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
      * @configkey implementedinterfaces
      * @configkey properties
      * @configkey methods
-     *
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return self
@@ -328,7 +301,6 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
     }
 
     /**
-     * @param  FileGenerator $fileGenerator
      * @return self
      */
     public function setContainingFileGenerator(FileGenerator $fileGenerator)
@@ -346,7 +318,6 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
     }
 
     /**
-     * @param  DocBlockGenerator $docBlock
      * @return self
      */
     public function setDocBlock(DocBlockGenerator $docBlock)
@@ -489,7 +460,6 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
 
     /**
      * @return string
-     *
      * @psalm-return array<class-string>
      */
     public function getImplementedInterfaces()
@@ -507,7 +477,7 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
 
         return (bool) array_filter(
             array_map([TypeGenerator::class, 'fromTypeString'], $this->implementedInterfaces),
-            static fn (TypeGenerator $interface) : bool => $interfaceType->equals($interface)
+            static fn (TypeGenerator $interface): bool => $interfaceType->equals($interface)
         );
     }
 
@@ -522,7 +492,7 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
 
         $this->implementedInterfaces = array_filter(
             array_map([TypeGenerator::class, 'fromTypeString'], $this->implementedInterfaces),
-            static fn (TypeGenerator $interface) : bool => ! $interfaceType->equals($interface)
+            static fn (TypeGenerator $interface): bool => ! $interfaceType->equals($interface)
         );
 
         return $this;
@@ -572,7 +542,6 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
     /**
      * Add constant from PropertyGenerator
      *
-     * @param  PropertyGenerator           $constant
      * @throws Exception\InvalidArgumentException
      * @return self
      */
@@ -604,9 +573,7 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
      *
      * @param  string                      $name Non-empty string
      * @param  string|int|null|float|array $value Scalar
-     *
      * @throws Exception\InvalidArgumentException
-     *
      * @return self
      */
     public function addConstant($name, $value)
@@ -627,7 +594,6 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
 
     /**
      * @param  PropertyGenerator[]|array[] $constants
-     *
      * @return self
      */
     public function addConstants(array $constants)
@@ -680,7 +646,7 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
         if (! is_string($name)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s::%s expects string for name',
-                get_class($this),
+                static::class,
                 __FUNCTION__
             ));
         }
@@ -697,7 +663,6 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
     /**
      * Add property from PropertyGenerator
      *
-     * @param  PropertyGenerator           $property
      * @throws Exception\InvalidArgumentException
      * @return self
      */
@@ -868,7 +833,7 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
         if (! is_string($name)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s::%s expects string for name',
-                get_class($this),
+                static::class,
                 __FUNCTION__
             ));
         }
@@ -879,7 +844,6 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
     /**
      * Add Method from MethodGenerator
      *
-     * @param  MethodGenerator                    $method
      * @throws Exception\InvalidArgumentException
      * @return self
      */
@@ -1095,14 +1059,14 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
 
         if (! empty($implemented)) {
             $implemented = array_map([$this, 'generateShortOrCompleteClassname'], $implemented);
-            $output .= ' ' . static::IMPLEMENTS_KEYWORD . ' ' . implode(', ', $implemented);
+            $output     .= ' ' . static::IMPLEMENTS_KEYWORD . ' ' . implode(', ', $implemented);
         }
 
-        $output .= self::LINE_FEED . '{' . self::LINE_FEED;
+        $output        .= self::LINE_FEED . '{' . self::LINE_FEED;
         $traitUseOutput = rtrim($this->traitUsageGenerator->generate(), self::LINE_FEED);
-        $constants = [];
-        $properties = [];
-        $methods = [];
+        $constants      = [];
+        $properties     = [];
+        $methods        = [];
 
         foreach ($this->getConstants() as $constant) {
             $constants[] = $constant->generate();
@@ -1138,9 +1102,7 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
 
     /**
      * @param mixed $value
-     *
      * @return void
-     *
      * @throws Exception\InvalidArgumentException
      */
     private function validateConstantValue($value)
@@ -1163,15 +1125,14 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
 
     /**
      * @param string $fqnClassName
-     *
      * @return string
      */
     private function generateShortOrCompleteClassname($fqnClassName)
     {
-        $fqnClassName = ltrim($fqnClassName, '\\');
-        $parts = explode('\\', $fqnClassName);
-        $className = array_pop($parts);
-        $classNamespace = implode('\\', $parts);
+        $fqnClassName     = ltrim($fqnClassName, '\\');
+        $parts            = explode('\\', $fqnClassName);
+        $className        = array_pop($parts);
+        $classNamespace   = implode('\\', $parts);
         $currentNamespace = (string) $this->getNamespaceName();
 
         if ($this->hasUseAlias($fqnClassName)) {

--- a/src/Generator/DocBlock/Tag.php
+++ b/src/Generator/DocBlock/Tag.php
@@ -17,9 +17,9 @@ use Laminas\Code\Reflection\DocBlock\Tag\TagInterface as ReflectionTagInterface;
 class Tag extends GenericTag
 {
     /**
-     * @param  ReflectionTagInterface $reflectionTag
-     * @return Tag
      * @deprecated Deprecated in 2.3. Use TagManager::createTagFromReflection() instead
+     *
+     * @return Tag
      */
     public static function fromReflection(ReflectionTagInterface $reflectionTag)
     {
@@ -29,9 +29,10 @@ class Tag extends GenericTag
     }
 
     /**
+     * @deprecated Deprecated in 2.3. Use GenericTag::setContent() instead
+     *
      * @param  string $description
      * @return Tag
-     * @deprecated Deprecated in 2.3. Use GenericTag::setContent() instead
      */
     public function setDescription($description)
     {
@@ -39,8 +40,9 @@ class Tag extends GenericTag
     }
 
     /**
-     * @return string
      * @deprecated Deprecated in 2.3. Use GenericTag::getContent() instead
+     *
+     * @return string
      */
     public function getDescription()
     {

--- a/src/Generator/DocBlock/Tag/AbstractTypeableTag.php
+++ b/src/Generator/DocBlock/Tag/AbstractTypeableTag.php
@@ -22,14 +22,10 @@ use function is_string;
  */
 abstract class AbstractTypeableTag extends AbstractGenerator
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $description;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $types = [];
 
     /**

--- a/src/Generator/DocBlock/Tag/AuthorTag.php
+++ b/src/Generator/DocBlock/Tag/AuthorTag.php
@@ -14,14 +14,10 @@ use Laminas\Code\Reflection\DocBlock\Tag\TagInterface as ReflectionTagInterface;
 
 class AuthorTag extends AbstractGenerator implements TagInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $authorName;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $authorEmail;
 
     /**
@@ -40,9 +36,9 @@ class AuthorTag extends AbstractGenerator implements TagInterface
     }
 
     /**
-     * @param ReflectionTagInterface $reflectionTag
-     * @return AuthorTag
      * @deprecated Deprecated in 2.3. Use TagManager::createTagFromReflection() instead
+     *
+     * @return AuthorTag
      */
     public static function fromReflection(ReflectionTagInterface $reflectionTag)
     {
@@ -100,10 +96,8 @@ class AuthorTag extends AbstractGenerator implements TagInterface
      */
     public function generate()
     {
-        $output = '@author'
+        return '@author'
             . (! empty($this->authorName) ? ' ' . $this->authorName : '')
             . (! empty($this->authorEmail) ? ' <' . $this->authorEmail . '>' : '');
-
-        return $output;
     }
 }

--- a/src/Generator/DocBlock/Tag/GenericTag.php
+++ b/src/Generator/DocBlock/Tag/GenericTag.php
@@ -15,14 +15,10 @@ use function ltrim;
 
 class GenericTag extends AbstractGenerator implements TagInterface, PrototypeGenericInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $name;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $content;
 
     /**
@@ -81,9 +77,7 @@ class GenericTag extends AbstractGenerator implements TagInterface, PrototypeGen
      */
     public function generate()
     {
-        $output = '@' . $this->name
+        return '@' . $this->name
             . (! empty($this->content) ? ' ' . $this->content : '');
-
-        return $output;
     }
 }

--- a/src/Generator/DocBlock/Tag/LicenseTag.php
+++ b/src/Generator/DocBlock/Tag/LicenseTag.php
@@ -14,14 +14,10 @@ use Laminas\Code\Reflection\DocBlock\Tag\TagInterface as ReflectionTagInterface;
 
 class LicenseTag extends AbstractGenerator implements TagInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $url;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $licenseName;
 
     /**
@@ -40,9 +36,9 @@ class LicenseTag extends AbstractGenerator implements TagInterface
     }
 
     /**
-     * @param ReflectionTagInterface $reflectionTag
-     * @return ReturnTag
      * @deprecated Deprecated in 2.3. Use TagManager::createTagFromReflection() instead
+     *
+     * @return ReturnTag
      */
     public static function fromReflection(ReflectionTagInterface $reflectionTag)
     {
@@ -100,10 +96,8 @@ class LicenseTag extends AbstractGenerator implements TagInterface
      */
     public function generate()
     {
-        $output = '@license'
+        return '@license'
             . (! empty($this->url) ? ' ' . $this->url : '')
             . (! empty($this->licenseName) ? ' ' . $this->licenseName : '');
-
-        return $output;
     }
 }

--- a/src/Generator/DocBlock/Tag/MethodTag.php
+++ b/src/Generator/DocBlock/Tag/MethodTag.php
@@ -12,14 +12,10 @@ use function rtrim;
 
 class MethodTag extends AbstractTypeableTag implements TagInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $methodName;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $isStatic = false;
 
     /**
@@ -88,12 +84,10 @@ class MethodTag extends AbstractTypeableTag implements TagInterface
      */
     public function generate()
     {
-        $output = '@method'
+        return '@method'
             . ($this->isStatic ? ' static' : '')
             . (! empty($this->types) ? ' ' . $this->getTypesAsString() : '')
             . (! empty($this->methodName) ? ' ' . $this->methodName . '()' : '')
             . (! empty($this->description) ? ' ' . $this->description : '');
-
-        return $output;
     }
 }

--- a/src/Generator/DocBlock/Tag/ParamTag.php
+++ b/src/Generator/DocBlock/Tag/ParamTag.php
@@ -15,9 +15,7 @@ use function ltrim;
 
 class ParamTag extends AbstractTypeableTag implements TagInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $variableName;
 
     /**
@@ -35,9 +33,9 @@ class ParamTag extends AbstractTypeableTag implements TagInterface
     }
 
     /**
-     * @param ReflectionTagInterface $reflectionTag
-     * @return ParamTag
      * @deprecated Deprecated in 2.3. Use TagManager::createTagFromReflection() instead
+     *
+     * @return ParamTag
      */
     public static function fromReflection(ReflectionTagInterface $reflectionTag)
     {
@@ -73,9 +71,10 @@ class ParamTag extends AbstractTypeableTag implements TagInterface
     }
 
     /**
+     * @deprecated Deprecated in 2.3. Use setTypes() instead
+     *
      * @param string $datatype
      * @return ParamTag
-     * @deprecated Deprecated in 2.3. Use setTypes() instead
      */
     public function setDatatype($datatype)
     {
@@ -83,8 +82,9 @@ class ParamTag extends AbstractTypeableTag implements TagInterface
     }
 
     /**
-     * @return string
      * @deprecated Deprecated in 2.3. Use getTypes() or getTypesAsString() instead
+     *
+     * @return string
      */
     public function getDatatype()
     {
@@ -92,9 +92,10 @@ class ParamTag extends AbstractTypeableTag implements TagInterface
     }
 
     /**
+     * @deprecated Deprecated in 2.3. Use setVariableName() instead
+     *
      * @param  string $paramName
      * @return ParamTag
-     * @deprecated Deprecated in 2.3. Use setVariableName() instead
      */
     public function setParamName($paramName)
     {
@@ -102,8 +103,9 @@ class ParamTag extends AbstractTypeableTag implements TagInterface
     }
 
     /**
-     * @return string
      * @deprecated Deprecated in 2.3. Use getVariableName() instead
+     *
+     * @return string
      */
     public function getParamName()
     {
@@ -115,11 +117,9 @@ class ParamTag extends AbstractTypeableTag implements TagInterface
      */
     public function generate()
     {
-        $output = '@param'
+        return '@param'
             . (! empty($this->types) ? ' ' . $this->getTypesAsString() : '')
             . (! empty($this->variableName) ? ' $' . $this->variableName : '')
             . (! empty($this->description) ? ' ' . $this->description : '');
-
-        return $output;
     }
 }

--- a/src/Generator/DocBlock/Tag/PropertyTag.php
+++ b/src/Generator/DocBlock/Tag/PropertyTag.php
@@ -12,9 +12,7 @@ use function ltrim;
 
 class PropertyTag extends AbstractTypeableTag implements TagInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $propertyName;
 
     /**
@@ -62,11 +60,9 @@ class PropertyTag extends AbstractTypeableTag implements TagInterface
      */
     public function generate()
     {
-        $output = '@property'
+        return '@property'
             . (! empty($this->types) ? ' ' . $this->getTypesAsString() : '')
             . (! empty($this->propertyName) ? ' $' . $this->propertyName : '')
             . (! empty($this->description) ? ' ' . $this->description : '');
-
-        return $output;
     }
 }

--- a/src/Generator/DocBlock/Tag/ReturnTag.php
+++ b/src/Generator/DocBlock/Tag/ReturnTag.php
@@ -14,9 +14,9 @@ use Laminas\Code\Reflection\DocBlock\Tag\TagInterface as ReflectionTagInterface;
 class ReturnTag extends AbstractTypeableTag implements TagInterface
 {
     /**
-     * @param ReflectionTagInterface $reflectionTag
-     * @return ReturnTag
      * @deprecated Deprecated in 2.3. Use TagManager::createTagFromReflection() instead
+     *
+     * @return ReturnTag
      */
     public static function fromReflection(ReflectionTagInterface $reflectionTag)
     {
@@ -34,9 +34,10 @@ class ReturnTag extends AbstractTypeableTag implements TagInterface
     }
 
     /**
+     * @deprecated Deprecated in 2.3. Use setTypes() instead
+     *
      * @param string $datatype
      * @return ReturnTag
-     * @deprecated Deprecated in 2.3. Use setTypes() instead
      */
     public function setDatatype($datatype)
     {
@@ -44,8 +45,9 @@ class ReturnTag extends AbstractTypeableTag implements TagInterface
     }
 
     /**
-     * @return string
      * @deprecated Deprecated in 2.3. Use getTypes() or getTypesAsString() instead
+     *
+     * @return string
      */
     public function getDatatype()
     {
@@ -57,10 +59,8 @@ class ReturnTag extends AbstractTypeableTag implements TagInterface
      */
     public function generate()
     {
-        $output = '@return '
+        return '@return '
         . $this->getTypesAsString()
         . (! empty($this->description) ? ' ' . $this->description : '');
-
-        return $output;
     }
 }

--- a/src/Generator/DocBlock/Tag/ThrowsTag.php
+++ b/src/Generator/DocBlock/Tag/ThrowsTag.php
@@ -23,10 +23,8 @@ class ThrowsTag extends AbstractTypeableTag implements TagInterface
      */
     public function generate()
     {
-        $output = '@throws'
+        return '@throws'
         . (! empty($this->types) ? ' ' . $this->getTypesAsString() : '')
         . (! empty($this->description) ? ' ' . $this->description : '');
-
-        return $output;
     }
 }

--- a/src/Generator/DocBlock/Tag/VarTag.php
+++ b/src/Generator/DocBlock/Tag/VarTag.php
@@ -8,17 +8,15 @@
 
 namespace Laminas\Code\Generator\DocBlock\Tag;
 
+use function ltrim;
+
 class VarTag extends AbstractTypeableTag implements TagInterface
 {
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     private $variableName;
 
     /**
-     * @param string|null     $variableName
      * @param string|string[] $types
-     * @param string|null     $description
      */
     public function __construct(?string $variableName = null, $types = [], ?string $description = null)
     {
@@ -32,24 +30,25 @@ class VarTag extends AbstractTypeableTag implements TagInterface
     /**
      * {@inheritDoc}
      */
-    public function getName() : string
+    public function getName(): string
     {
         return 'var';
     }
 
     /**
      * @internal this code is only public for compatibility with the
-     *           @see \Laminas\Code\Generator\DocBlock\TagManager, which
+     *
+     * @see \Laminas\Code\Generator\DocBlock\TagManager, which
      *           uses setters
      */
-    public function setVariableName(?string $variableName) : void
+    public function setVariableName(?string $variableName): void
     {
         if (null !== $variableName) {
             $this->variableName = ltrim($variableName, '$');
         }
     }
 
-    public function getVariableName() : ?string
+    public function getVariableName(): ?string
     {
         return $this->variableName;
     }
@@ -57,11 +56,11 @@ class VarTag extends AbstractTypeableTag implements TagInterface
     /**
      * {@inheritDoc}
      */
-    public function generate() : string
+    public function generate(): string
     {
         return '@var'
-            . ((! empty($this->types)) ? ' ' . $this->getTypesAsString() : '')
+            . (! empty($this->types) ? ' ' . $this->getTypesAsString() : '')
             . (null !== $this->variableName ? ' $' . $this->variableName : '')
-            . ((! empty($this->description)) ? ' ' . $this->description : '');
+            . (! empty($this->description) ? ' ' . $this->description : '');
     }
 }

--- a/src/Generator/DocBlock/TagManager.php
+++ b/src/Generator/DocBlock/TagManager.php
@@ -11,6 +11,8 @@ namespace Laminas\Code\Generator\DocBlock;
 use Laminas\Code\Generator\DocBlock\Tag\TagInterface;
 use Laminas\Code\Generic\Prototype\PrototypeClassFactory;
 use Laminas\Code\Reflection\DocBlock\Tag\TagInterface as ReflectionTagInterface;
+use ReflectionClass;
+use ReflectionMethod;
 
 use function method_exists;
 use function strpos;
@@ -44,19 +46,18 @@ class TagManager extends PrototypeClassFactory
     }
 
     /**
-     * @param ReflectionTagInterface $reflectionTag
      * @return TagInterface
      */
     public function createTagFromReflection(ReflectionTagInterface $reflectionTag)
     {
         $tagName = $reflectionTag->getName();
 
-        /* @var TagInterface $newTag */
+        /** @var TagInterface $newTag */
         $newTag = $this->getClonedPrototype($tagName);
 
         // transport any properties via accessors and mutators from reflection to codegen object
-        $reflectionClass = new \ReflectionClass($reflectionTag);
-        foreach ($reflectionClass->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+        $reflectionClass = new ReflectionClass($reflectionTag);
+        foreach ($reflectionClass->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
             if (0 === strpos($method->getName(), 'get')) {
                 $propertyName = substr($method->getName(), 3);
                 if (method_exists($newTag, 'set' . $propertyName)) {

--- a/src/Generator/DocBlockGenerator.php
+++ b/src/Generator/DocBlockGenerator.php
@@ -23,40 +23,27 @@ use function wordwrap;
 
 class DocBlockGenerator extends AbstractGenerator
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $shortDescription;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $longDescription;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $tags = [];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $indentation = '';
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $wordwrap = true;
 
-    /**
-     * @var TagManager|null
-     */
+    /** @var TagManager|null */
     protected static $tagManager;
 
     /**
      * Build a DocBlock generator object from a reflection object
      *
-     * @param  DocBlockReflection $reflectionDocBlock
      * @return DocBlockGenerator
      */
     public static function fromReflection(DocBlockReflection $reflectionDocBlock)
@@ -82,7 +69,6 @@ class DocBlockGenerator extends AbstractGenerator
      * @configkey shortdescription string The short description for this doc block
      * @configkey longdescription  string The long description for this doc block
      * @configkey tags             array
-     *
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return DocBlockGenerator
@@ -255,7 +241,7 @@ class DocBlockGenerator extends AbstractGenerator
             $output .= $ld . self::LINE_FEED . self::LINE_FEED;
         }
 
-        /* @var $tag GeneratorInterface */
+        /** @var GeneratorInterface $tag */
         foreach ($this->getTags() as $tag) {
             $output .= $tag->generate() . self::LINE_FEED;
         }

--- a/src/Generator/GeneratorInterface.php
+++ b/src/Generator/GeneratorInterface.php
@@ -10,5 +10,6 @@ namespace Laminas\Code\Generator;
 
 interface GeneratorInterface
 {
+    /** @return string */
     public function generate();
 }

--- a/src/Generator/InterfaceGenerator.php
+++ b/src/Generator/InterfaceGenerator.php
@@ -16,14 +16,13 @@ use function strtolower;
 
 class InterfaceGenerator extends ClassGenerator
 {
-    const OBJECT_TYPE = 'interface';
-    const IMPLEMENTS_KEYWORD = 'extends';
+    public const OBJECT_TYPE        = 'interface';
+    public const IMPLEMENTS_KEYWORD = 'extends';
 
     /**
      * Build a Code Generation Php Object from a Class Reflection
      *
-     * @param  ClassReflection $classReflection
-     * @return InterfaceGenerator
+     * @return static
      */
     public static function fromReflection(ClassReflection $classReflection)
     {
@@ -78,7 +77,6 @@ class InterfaceGenerator extends ClassGenerator
      * @configkey docblock       string        The docblock information
      * @configkey constants
      * @configkey methods
-     *
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return InterfaceGenerator

--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -9,7 +9,6 @@
 namespace Laminas\Code\Generator;
 
 use Laminas\Code\Reflection\MethodReflection;
-use ReflectionMethod;
 
 use function explode;
 use function implode;
@@ -25,33 +24,22 @@ use function trim;
 
 class MethodGenerator extends AbstractMemberGenerator
 {
-    /**
-     * @var DocBlockGenerator
-     */
+    /** @var DocBlockGenerator */
     protected $docBlock;
 
-    /**
-     * @var ParameterGenerator[]
-     */
+    /** @var ParameterGenerator[] */
     protected $parameters = [];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $body;
 
-    /**
-     * @var null|TypeGenerator
-     */
+    /** @var null|TypeGenerator */
     private $returnType;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $returnsReference = false;
 
     /**
-     * @param  MethodReflection $reflectionMethod
      * @return MethodGenerator
      */
     public static function fromReflection(MethodReflection $reflectionMethod)
@@ -109,7 +97,6 @@ class MethodGenerator extends AbstractMemberGenerator
      * from all lines
      *
      * @param string $body
-     *
      * @return string
      */
     protected static function clearBodyIndention($body)
@@ -145,7 +132,6 @@ class MethodGenerator extends AbstractMemberGenerator
      * @configkey final          bool
      * @configkey static         bool
      * @configkey visibility     string
-     *
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return MethodGenerator
@@ -299,7 +285,6 @@ class MethodGenerator extends AbstractMemberGenerator
 
     /**
      * @param string|null $returnType
-     *
      * @return MethodGenerator
      */
     public function setReturnType($returnType = null)
@@ -321,7 +306,6 @@ class MethodGenerator extends AbstractMemberGenerator
 
     /**
      * @param bool $returnsReference
-     *
      * @return MethodGenerator
      */
     public function setReturnsReference($returnsReference)
@@ -394,27 +378,9 @@ class MethodGenerator extends AbstractMemberGenerator
         return $output;
     }
 
+    /** @return string */
     public function __toString()
     {
         return $this->generate();
-    }
-
-    /**
-     * @param string           $literalReturnType
-     * @param ReflectionMethod $methodReflection
-     *
-     * @return string
-     */
-    private static function expandLiteralType($literalReturnType, ReflectionMethod $methodReflection)
-    {
-        if ('self' === strtolower($literalReturnType)) {
-            return $methodReflection->getDeclaringClass()->getName();
-        }
-
-        if ('parent' === strtolower($literalReturnType)) {
-            return $methodReflection->getDeclaringClass()->getParentClass()->getName();
-        }
-
-        return $literalReturnType;
     }
 }

--- a/src/Generator/ParameterGenerator.php
+++ b/src/Generator/ParameterGenerator.php
@@ -9,50 +9,35 @@
 namespace Laminas\Code\Generator;
 
 use Laminas\Code\Reflection\ParameterReflection;
+use ReflectionException;
 
-use function method_exists;
 use function str_replace;
 use function strtolower;
 
 class ParameterGenerator extends AbstractGenerator
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $name;
 
-    /**
-     * @var TypeGenerator|null
-     */
+    /** @var TypeGenerator|null */
     protected $type;
 
-    /**
-     * @var ValueGenerator
-     */
+    /** @var ValueGenerator */
     protected $defaultValue;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $position;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $passedByReference = false;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $variadic = false;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $omitDefaultValue = false;
 
     /**
-     * @param  ParameterReflection $reflectionParameter
      * @return ParameterGenerator
      */
     public static function fromReflection(ParameterReflection $reflectionParameter)
@@ -60,7 +45,10 @@ class ParameterGenerator extends AbstractGenerator
         $param = new ParameterGenerator();
 
         $param->setName($reflectionParameter->getName());
-        $param->type = TypeGenerator::fromReflectionType($reflectionParameter->getType(), $reflectionParameter->getDeclaringClass());
+        $param->type = TypeGenerator::fromReflectionType(
+            $reflectionParameter->getType(),
+            $reflectionParameter->getDeclaringClass()
+        );
 
         $param->setPosition($reflectionParameter->getPosition());
 
@@ -71,7 +59,7 @@ class ParameterGenerator extends AbstractGenerator
         if (! $variadic && ($reflectionParameter->isOptional() || $reflectionParameter->isDefaultValueAvailable())) {
             try {
                 $param->setDefaultValue($reflectionParameter->getDefaultValue());
-            } catch (\ReflectionException $e) {
+            } catch (ReflectionException $e) {
                 $param->setDefaultValue(null);
             }
         }
@@ -93,7 +81,6 @@ class ParameterGenerator extends AbstractGenerator
      * @configkey indentation           string
      * @configkey sourcecontent         string
      * @configkey omitdefaultvalue      bool
-     *
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return ParameterGenerator
@@ -274,7 +261,6 @@ class ParameterGenerator extends AbstractGenerator
 
     /**
      * @param bool $variadic
-     *
      * @return ParameterGenerator
      */
     public function setVariadic($variadic)
@@ -335,7 +321,6 @@ class ParameterGenerator extends AbstractGenerator
     }
 
     /**
-     * @param bool $omit
      * @return ParameterGenerator
      */
     public function omitDefaultValue(bool $omit = true)

--- a/src/Generator/PropertyGenerator.php
+++ b/src/Generator/PropertyGenerator.php
@@ -16,26 +16,19 @@ use function strtolower;
 
 class PropertyGenerator extends AbstractMemberGenerator
 {
-    const FLAG_CONSTANT = 0x08;
+    public const FLAG_CONSTANT = 0x08;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $isConst;
 
-    /**
-     * @var PropertyValueGenerator
-     */
+    /** @var PropertyValueGenerator */
     protected $defaultValue;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $omitDefaultValue = false;
 
     /**
-     * @param  PropertyReflection $reflectionProperty
-     * @return PropertyGenerator
+     * @return static
      */
     public static function fromReflection(PropertyReflection $reflectionProperty)
     {
@@ -84,10 +77,9 @@ class PropertyGenerator extends AbstractMemberGenerator
      * @configkey static             bool
      * @configkey visibility         string
      * @configkey omitdefaultvalue   bool
-     *
      * @throws Exception\InvalidArgumentException
      * @param  array $array
-     * @return PropertyGenerator
+     * @return static
      */
     public static function fromArray(array $array)
     {
@@ -180,8 +172,7 @@ class PropertyGenerator extends AbstractMemberGenerator
      * @param PropertyValueGenerator|mixed $defaultValue
      * @param string                       $defaultValueType
      * @param string                       $defaultValueOutputMode
-     *
-     * @return PropertyGenerator
+     * @return $this
      */
     public function setDefaultValue(
         $defaultValue,
@@ -229,10 +220,8 @@ class PropertyGenerator extends AbstractMemberGenerator
                     $this->name
                 ));
             }
-            $output .= $this->indentation . $this->getVisibility() . ' const ' . $name . ' = '
+            return $output . $this->indentation . $this->getVisibility() . ' const ' . $name . ' = '
                 . ($defaultValue !== null ? $defaultValue->generate() : 'null;');
-
-            return $output;
         }
 
         $output .= $this->indentation . $this->getVisibility() . ($this->isStatic() ? ' static' : '') . ' $' . $name;
@@ -245,7 +234,6 @@ class PropertyGenerator extends AbstractMemberGenerator
     }
 
     /**
-     * @param bool $omit
      * @return PropertyGenerator
      */
     public function omitDefaultValue(bool $omit = true)

--- a/src/Generator/PropertyValueGenerator.php
+++ b/src/Generator/PropertyValueGenerator.php
@@ -10,6 +10,7 @@ namespace Laminas\Code\Generator;
 
 class PropertyValueGenerator extends ValueGenerator
 {
+    /** @var int */
     protected $arrayDepth = 1;
 
     /**

--- a/src/Generator/TraitGenerator.php
+++ b/src/Generator/TraitGenerator.php
@@ -15,13 +15,12 @@ use function strtolower;
 
 class TraitGenerator extends ClassGenerator
 {
-    const OBJECT_TYPE = 'trait';
+    public const OBJECT_TYPE = 'trait';
 
     /**
      * Build a Code Generation Php Object from a Class Reflection
      *
-     * @param  ClassReflection $classReflection
-     * @return TraitGenerator
+     * @return static
      */
     public static function fromReflection(ClassReflection $classReflection)
     {
@@ -71,7 +70,6 @@ class TraitGenerator extends ClassGenerator
      * @configkey docblock       string        The docblock information
      * @configkey properties
      * @configkey methods
-     *
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return TraitGenerator

--- a/src/Generator/TraitUsageGenerator.php
+++ b/src/Generator/TraitUsageGenerator.php
@@ -26,29 +26,19 @@ use function strpos;
 
 class TraitUsageGenerator extends AbstractGenerator implements TraitUsageInterface
 {
-    /**
-     * @var ClassGenerator
-     */
+    /** @var ClassGenerator */
     protected $classGenerator;
 
-    /**
-     * @var array Array of trait names
-     */
+    /** @var array Array of trait names */
     protected $traits = [];
 
-    /**
-     * @var array Array of trait aliases
-     */
+    /** @var array Array of trait aliases */
     protected $traitAliases = [];
 
-    /**
-     * @var array Array of trait overrides
-     */
+    /** @var array Array of trait overrides */
     protected $traitOverrides = [];
 
-    /**
-     * @var array Array of string names
-     */
+    /** @var array Array of string names */
     protected $uses = [];
 
     public function __construct(ClassGenerator $classGenerator)
@@ -113,9 +103,6 @@ class TraitUsageGenerator extends AbstractGenerator implements TraitUsageInterfa
 
     /**
      * Returns the alias of the provided FQCN
-     *
-     * @param string $use
-     * @return string|null
      */
     public function getUseAlias(string $use): ?string
     {
@@ -130,9 +117,6 @@ class TraitUsageGenerator extends AbstractGenerator implements TraitUsageInterfa
 
     /**
      * Returns true if the alias is defined in the use list
-     *
-     * @param string $alias
-     * @return bool
      */
     public function isUseAlias(string $alias): bool
     {
@@ -280,7 +264,8 @@ class TraitUsageGenerator extends AbstractGenerator implements TraitUsageInterfa
         if ($this->classGenerator->hasMethod($alias)) {
             throw new Exception\InvalidArgumentException('Invalid Alias: Method name already exists on this class.');
         }
-        if (null !== $visibility
+        if (
+            null !== $visibility
             && $visibility !== ReflectionMethod::IS_PUBLIC
             && $visibility !== ReflectionMethod::IS_PRIVATE
             && $visibility !== ReflectionMethod::IS_PROTECTED
@@ -291,7 +276,7 @@ class TraitUsageGenerator extends AbstractGenerator implements TraitUsageInterfa
             );
         }
 
-        list($trait, $method) = explode('::', $traitAndMethod);
+        [$trait, $method] = explode('::', $traitAndMethod);
         if (! $this->hasTrait($trait)) {
             throw new Exception\InvalidArgumentException('Invalid trait: Trait does not exists on this class');
         }
@@ -341,7 +326,7 @@ class TraitUsageGenerator extends AbstractGenerator implements TraitUsageInterfa
             );
         }
 
-        list($trait, $method) = explode('::', $traitAndMethod);
+        [$trait, $method] = explode('::', $traitAndMethod);
         if (! $this->hasTrait($trait)) {
             throw new Exception\InvalidArgumentException('Invalid trait: Trait does not exists on this class');
         }
@@ -417,8 +402,7 @@ class TraitUsageGenerator extends AbstractGenerator implements TraitUsageInterfa
         $aliases   = $this->getTraitAliases();
         $overrides = $this->getTraitOverrides();
         if (empty($aliases) && empty($overrides)) {
-            $output .= ';' . self::LINE_FEED . self::LINE_FEED;
-            return $output;
+            return $output . ';' . self::LINE_FEED . self::LINE_FEED;
         }
 
         $output .= ' {' . self::LINE_FEED;
@@ -459,8 +443,6 @@ class TraitUsageGenerator extends AbstractGenerator implements TraitUsageInterfa
             }
         }
 
-        $output .= self::LINE_FEED . $indent . '}' . self::LINE_FEED . self::LINE_FEED;
-
-        return $output;
+        return $output . self::LINE_FEED . $indent . '}' . self::LINE_FEED . self::LINE_FEED;
     }
 }

--- a/src/Generator/TypeGenerator.php
+++ b/src/Generator/TypeGenerator.php
@@ -9,12 +9,12 @@
 namespace Laminas\Code\Generator;
 
 use Laminas\Code\Generator\Exception\InvalidArgumentException;
-
 use Laminas\Code\Generator\TypeGenerator\AtomicType;
 use ReflectionClass;
 use ReflectionNamedType;
 use ReflectionType;
 use ReflectionUnionType;
+
 use function array_diff_key;
 use function array_flip;
 use function array_map;
@@ -33,28 +33,10 @@ final class TypeGenerator implements GeneratorInterface
 {
     /**
      * @var AtomicType[]
-     *
      * @psalm-var non-empty-list<AtomicType>
      */
     private array $types;
     private bool $nullable;
-    /**
-     * @var string[]
-     *
-     * @link http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration
-     */
-    private static $internalPhpTypes = [
-        'void',
-        'int',
-        'float',
-        'string',
-        'bool',
-        'array',
-        'callable',
-        'iterable',
-        'object',
-        'null',
-    ];
 
     /**
      * @internal
@@ -111,13 +93,12 @@ final class TypeGenerator implements GeneratorInterface
 
     /**
      * @throws InvalidArgumentException
-     *
      * @psalm-pure
      */
     public static function fromTypeString(string $type): self
     {
         [$nullable, $trimmedNullable] = self::trimNullable($type);
-        $types = array_map([AtomicType::class, 'fromString'], explode('|', $trimmedNullable));
+        $types                        = array_map([AtomicType::class, 'fromString'], explode('|', $trimmedNullable));
 
         usort(
             $types,
@@ -157,7 +138,6 @@ final class TypeGenerator implements GeneratorInterface
 
     /**
      * @param AtomicType[]                     $types
-     *
      * @psalm-param non-empty-list<AtomicType> $types
      */
     private function __construct(array $types, bool $nullable)
@@ -209,12 +189,9 @@ final class TypeGenerator implements GeneratorInterface
 
     /**
      * @param string $type
-     *
      * @return bool[]|string[] ordered tuple, first key represents whether the type is nullable, second is the
      *                         trimmed string
-     *
      * @psalm-return array{bool, string}
-     *
      * @psalm-pure
      */
     private static function trimNullable($type)

--- a/src/Generator/TypeGenerator/AtomicType.php
+++ b/src/Generator/TypeGenerator/AtomicType.php
@@ -15,6 +15,7 @@ use function array_key_exists;
 use function assert;
 use function implode;
 use function preg_match;
+use function sprintf;
 use function strtolower;
 use function substr;
 
@@ -52,9 +53,9 @@ final class AtomicType
 
     /** @psalm-var array<non-empty-string, null> */
     private const NOT_NULLABLE_TYPES = [
-        'null' => null,
+        'null'  => null,
         'false' => null,
-        'void' => null,
+        'void'  => null,
         'mixed' => null,
     ];
 
@@ -74,18 +75,17 @@ final class AtomicType
      */
     private function __construct(string $type, int $sortIndex)
     {
-        $this->type = $type;
+        $this->type      = $type;
         $this->sortIndex = $sortIndex;
     }
 
     /**
      * @psalm-pure
-     *
      * @throws InvalidArgumentException
      */
     public static function fromString(string $type): self
     {
-        $trimmedType = '\\' === ($type[0] ?? '')
+        $trimmedType   = '\\' === ($type[0] ?? '')
             ? substr($type, 1)
             : $type;
         $lowerCaseType = strtolower($trimmedType);
@@ -103,7 +103,8 @@ final class AtomicType
 
         if (1 !== preg_match(self::VALID_IDENTIFIER_MATCHER, $trimmedType)) {
             throw new InvalidArgumentException(sprintf(
-                'Provided type "%s" is not recognized as a valid expression: it must match "%s" or be one of the built-in types (%s)',
+                'Provided type "%s" is not recognized as a valid expression: '
+                . 'it must match "%s" or be one of the built-in types (%s)',
                 $type,
                 self::VALID_IDENTIFIER_MATCHER,
                 implode(', ', self::BUILT_IN_TYPES_PRECEDENCE)
@@ -131,12 +132,12 @@ final class AtomicType
 
     /**
      * @psalm-param non-empty-array<self> $others
-     *
      * @throws InvalidArgumentException
      */
     public function assertCanUnionWith(array $others): void
     {
-        if ('mixed' === $this->type
+        if (
+            'mixed' === $this->type
             || 'void' === $this->type
         ) {
             throw new InvalidArgumentException(sprintf(
@@ -155,8 +156,9 @@ final class AtomicType
             }
         }
 
-        if ($this->requiresUnionWithStandaloneType() &&
-            [] === array_filter($others, static fn (self $type) : bool => ! $type->requiresUnionWithStandaloneType())
+        if (
+            $this->requiresUnionWithStandaloneType() &&
+            [] === array_filter($others, static fn (self $type): bool => ! $type->requiresUnionWithStandaloneType())
         ) {
             throw new InvalidArgumentException(sprintf(
                 'Type "%s" requires to be composed with non-standalone types',

--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -35,50 +35,40 @@ class ValueGenerator extends AbstractGenerator
     /**#@+
      * Constant values
      */
-    const TYPE_AUTO        = 'auto';
-    const TYPE_BOOLEAN     = 'boolean';
-    const TYPE_BOOL        = 'bool';
-    const TYPE_NUMBER      = 'number';
-    const TYPE_INTEGER     = 'integer';
-    const TYPE_INT         = 'int';
-    const TYPE_FLOAT       = 'float';
-    const TYPE_DOUBLE      = 'double';
-    const TYPE_STRING      = 'string';
-    const TYPE_ARRAY       = 'array';
-    const TYPE_ARRAY_SHORT = 'array_short';
-    const TYPE_ARRAY_LONG  = 'array_long';
-    const TYPE_CONSTANT    = 'constant';
-    const TYPE_NULL        = 'null';
-    const TYPE_OBJECT      = 'object';
-    const TYPE_OTHER       = 'other';
+    public const TYPE_AUTO        = 'auto';
+    public const TYPE_BOOLEAN     = 'boolean';
+    public const TYPE_BOOL        = 'bool';
+    public const TYPE_NUMBER      = 'number';
+    public const TYPE_INTEGER     = 'integer';
+    public const TYPE_INT         = 'int';
+    public const TYPE_FLOAT       = 'float';
+    public const TYPE_DOUBLE      = 'double';
+    public const TYPE_STRING      = 'string';
+    public const TYPE_ARRAY       = 'array';
+    public const TYPE_ARRAY_SHORT = 'array_short';
+    public const TYPE_ARRAY_LONG  = 'array_long';
+    public const TYPE_CONSTANT    = 'constant';
+    public const TYPE_NULL        = 'null';
+    public const TYPE_OBJECT      = 'object';
+    public const TYPE_OTHER       = 'other';
     /**#@-*/
 
-    const OUTPUT_MULTIPLE_LINE = 'multipleLine';
-    const OUTPUT_SINGLE_LINE   = 'singleLine';
+    public const OUTPUT_MULTIPLE_LINE = 'multipleLine';
+    public const OUTPUT_SINGLE_LINE   = 'singleLine';
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     protected $value;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $type = self::TYPE_AUTO;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $arrayDepth = 0;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $outputMode = self::OUTPUT_MULTIPLE_LINE;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $allowedTypes;
 
     /**
@@ -125,7 +115,7 @@ class ValueGenerator extends AbstractGenerator
      */
     public function initEnvironmentConstants()
     {
-        $constants   = [
+        $constants = [
             '__DIR__',
             '__FILE__',
             '__LINE__',
@@ -144,7 +134,6 @@ class ValueGenerator extends AbstractGenerator
      * Add constant to list
      *
      * @param string $constant
-     *
      * @return $this
      */
     public function addConstant($constant)
@@ -158,7 +147,6 @@ class ValueGenerator extends AbstractGenerator
      * Delete constant from constant list
      *
      * @param string $constant
-     *
      * @return bool
      */
     public function deleteConstant($constant)
@@ -398,7 +386,7 @@ class ValueGenerator extends AbstractGenerator
                     $endArray   = ')';
                 } else {
                     $startArray = '[';
-                    $endArray = ']';
+                    $endArray   = ']';
                 }
 
                 $output .= $startArray;
@@ -408,7 +396,7 @@ class ValueGenerator extends AbstractGenerator
                 $outputParts = [];
                 $noKeyIndex  = 0;
                 foreach ($value as $n => $v) {
-                    /* @var $v ValueGenerator */
+                    /** @var ValueGenerator $v */
                     $v->setArrayDepth($this->arrayDepth + 1);
                     $partV = $v->generate();
                     $short = false;
@@ -487,6 +475,7 @@ class ValueGenerator extends AbstractGenerator
         return $this->outputMode;
     }
 
+    /** @return string */
     public function __toString()
     {
         return $this->generate();

--- a/src/Generic/Prototype/PrototypeClassFactory.php
+++ b/src/Generic/Prototype/PrototypeClassFactory.php
@@ -27,21 +27,16 @@ use function str_replace;
  */
 class PrototypeClassFactory
 {
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $prototypes = [];
 
-    /**
-     * @var PrototypeGenericInterface|null
-     */
+    /** @var PrototypeGenericInterface|null */
     protected $genericPrototype;
 
     /**
      * @param PrototypeInterface[] $prototypes
-     * @param PrototypeGenericInterface $genericPrototype
      */
-    public function __construct($prototypes = [], PrototypeGenericInterface $genericPrototype = null)
+    public function __construct($prototypes = [], ?PrototypeGenericInterface $genericPrototype = null)
     {
         foreach ((array) $prototypes as $prototype) {
             $this->addPrototype($prototype);
@@ -53,7 +48,6 @@ class PrototypeClassFactory
     }
 
     /**
-     * @param PrototypeInterface $prototype
      * @throws Exception\InvalidArgumentException
      */
     public function addPrototype(PrototypeInterface $prototype)
@@ -68,7 +62,6 @@ class PrototypeClassFactory
     }
 
     /**
-     * @param PrototypeGenericInterface $prototype
      * @throws Exception\InvalidArgumentException
      */
     public function setGenericPrototype(PrototypeGenericInterface $prototype)

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -20,17 +20,14 @@ use function strstr;
 
 class ClassReflection extends ReflectionClass implements ReflectionInterface
 {
-
-    /**
-     * @var DocBlockReflection|null
-     */
+    /** @var DocBlockReflection|null */
     protected $docBlock;
 
     /**
      * Return the classes DocBlock reflection object
      *
      * @return DocBlockReflection|false
-     * @throws Exception\ExceptionInterface for missing DocBock or invalid reflection class
+     * @throws Exception\ExceptionInterface When missing DocBock or invalid reflection class.
      */
     public function getDocBlock()
     {
@@ -94,10 +91,10 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
      */
     public function getInterfaces()
     {
-        $phpReflections  = parent::getInterfaces();
+        $phpReflections     = parent::getInterfaces();
         $laminasReflections = [];
         while ($phpReflections && ($phpReflection = array_shift($phpReflections))) {
-            $instance          = new ClassReflection($phpReflection->getName());
+            $instance             = new ClassReflection($phpReflection->getName());
             $laminasReflections[] = $instance;
             unset($phpReflection);
         }
@@ -114,9 +111,7 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
      */
     public function getMethod($name)
     {
-        $method = new MethodReflection($this->getName(), parent::getMethod($name)->getName());
-
-        return $method;
+        return new MethodReflection($this->getName(), parent::getMethod($name)->getName());
     }
 
     /**
@@ -143,7 +138,7 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
      */
     public function getTraits()
     {
-        $vals = [];
+        $vals   = [];
         $traits = parent::getTraits();
         if ($traits === null) {
             return;
@@ -182,7 +177,7 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
      */
     public function getProperty($name)
     {
-        $phpReflection  = parent::getProperty($name);
+        $phpReflection     = parent::getProperty($name);
         $laminasReflection = new PropertyReflection($this->getName(), $phpReflection->getName());
         unset($phpReflection);
 
@@ -197,10 +192,10 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
      */
     public function getProperties($filter = -1)
     {
-        $phpReflections  = parent::getProperties($filter);
+        $phpReflections     = parent::getProperties($filter);
         $laminasReflections = [];
         while ($phpReflections && ($phpReflection = array_shift($phpReflections))) {
-            $instance          = new PropertyReflection($this->getName(), $phpReflection->getName());
+            $instance             = new PropertyReflection($this->getName(), $phpReflection->getName());
             $laminasReflections[] = $instance;
             unset($phpReflection);
         }

--- a/src/Reflection/DocBlock/Tag/AuthorTag.php
+++ b/src/Reflection/DocBlock/Tag/AuthorTag.php
@@ -13,14 +13,10 @@ use function rtrim;
 
 class AuthorTag implements TagInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $authorName;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $authorEmail;
 
     /**
@@ -69,6 +65,10 @@ class AuthorTag implements TagInterface
         return $this->authorEmail;
     }
 
+    /**
+     * @return string
+     * @psalm-return non-empty-string
+     */
     public function __toString()
     {
         return 'DocBlock Tag [ * @' . $this->getName() . ' ]' . "\n";

--- a/src/Reflection/DocBlock/Tag/GenericTag.php
+++ b/src/Reflection/DocBlock/Tag/GenericTag.php
@@ -15,24 +15,16 @@ use function trim;
 
 class GenericTag implements TagInterface, PrototypeGenericInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $name;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $content;
 
-    /**
-     * @var null|string
-     */
+    /** @var null|string */
     protected $contentSplitCharacter;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $values = [];
 
     /**
@@ -94,6 +86,7 @@ class GenericTag implements TagInterface, PrototypeGenericInterface
      *
      * @todo   What should this do?
      * @return string
+     * @psalm-return non-empty-string
      */
     public function __toString()
     {
@@ -106,6 +99,6 @@ class GenericTag implements TagInterface, PrototypeGenericInterface
     protected function parse($docBlockLine)
     {
         $this->content = trim($docBlockLine);
-        $this->values = explode($this->contentSplitCharacter, $docBlockLine);
+        $this->values  = explode($this->contentSplitCharacter, $docBlockLine);
     }
 }

--- a/src/Reflection/DocBlock/Tag/LicenseTag.php
+++ b/src/Reflection/DocBlock/Tag/LicenseTag.php
@@ -13,14 +13,10 @@ use function trim;
 
 class LicenseTag implements TagInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $url;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $licenseName;
 
     /**
@@ -69,6 +65,10 @@ class LicenseTag implements TagInterface
         return $this->licenseName;
     }
 
+    /**
+     * @return string
+     * @psalm-return non-empty-string
+     */
     public function __toString()
     {
         return 'DocBlock Tag [ * @' . $this->getName() . ' ]' . "\n";

--- a/src/Reflection/DocBlock/Tag/MethodTag.php
+++ b/src/Reflection/DocBlock/Tag/MethodTag.php
@@ -17,18 +17,15 @@ class MethodTag implements TagInterface, PhpDocTypedTagInterface
     /**
      * Return value type
      *
-     * @var array
+     * @var string[]
+     * @psalm-var list<string>
      */
     protected $types = [];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $methodName;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $description;
 
     /**
@@ -77,8 +74,9 @@ class MethodTag implements TagInterface, PhpDocTypedTagInterface
     /**
      * Get return value type
      *
-     * @return null|string
      * @deprecated 2.0.4 use getTypes instead
+     *
+     * @return null|string
      */
     public function getReturnType()
     {
@@ -89,6 +87,7 @@ class MethodTag implements TagInterface, PhpDocTypedTagInterface
         return $this->types[0];
     }
 
+    /** {@inheritDoc} */
     public function getTypes()
     {
         return $this->types;
@@ -118,6 +117,10 @@ class MethodTag implements TagInterface, PhpDocTypedTagInterface
         return $this->isStatic;
     }
 
+    /**
+     * @return string
+     * @psalm-return non-empty-string
+     */
     public function __toString()
     {
         return 'DocBlock Tag [ * @' . $this->getName() . ' ]' . "\n";

--- a/src/Reflection/DocBlock/Tag/ParamTag.php
+++ b/src/Reflection/DocBlock/Tag/ParamTag.php
@@ -16,18 +16,15 @@ use function trim;
 class ParamTag implements TagInterface, PhpDocTypedTagInterface
 {
     /**
-     * @var array
+     * @var string[]
+     * @psalm-return list<string>
      */
     protected $types = [];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $variableName;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $description;
 
     /**
@@ -65,8 +62,9 @@ class ParamTag implements TagInterface, PhpDocTypedTagInterface
     /**
      * Get parameter variable type
      *
-     * @return string
      * @deprecated 2.0.4 use getTypes instead
+     *
+     * @return string
      */
     public function getType()
     {
@@ -77,6 +75,7 @@ class ParamTag implements TagInterface, PhpDocTypedTagInterface
         return $this->types[0];
     }
 
+    /** {@inheritDoc} */
     public function getTypes()
     {
         return $this->types;

--- a/src/Reflection/DocBlock/Tag/PhpDocTypedTagInterface.php
+++ b/src/Reflection/DocBlock/Tag/PhpDocTypedTagInterface.php
@@ -14,6 +14,7 @@ interface PhpDocTypedTagInterface
      * Return all types supported by the tag definition
      *
      * @return string[]
+     * @psalm-return list<string>
      */
     public function getTypes();
 }

--- a/src/Reflection/DocBlock/Tag/PropertyTag.php
+++ b/src/Reflection/DocBlock/Tag/PropertyTag.php
@@ -15,18 +15,15 @@ use function rtrim;
 class PropertyTag implements TagInterface, PhpDocTypedTagInterface
 {
     /**
-     * @var array
+     * @var string[]
+     * @psalm-var list<string>
      */
     protected $types = [];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $propertyName;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $description;
 
     /**
@@ -63,8 +60,9 @@ class PropertyTag implements TagInterface, PhpDocTypedTagInterface
     }
 
     /**
-     * @return null|string
      * @deprecated 2.0.4 use getTypes instead
+     *
+     * @return null|string
      */
     public function getType()
     {
@@ -75,6 +73,7 @@ class PropertyTag implements TagInterface, PhpDocTypedTagInterface
         return $this->types[0];
     }
 
+    /** {@inheritDoc} */
     public function getTypes()
     {
         return $this->types;
@@ -96,6 +95,10 @@ class PropertyTag implements TagInterface, PhpDocTypedTagInterface
         return $this->description;
     }
 
+    /**
+     * @return string
+     * @psalm-return non-empty-string
+     */
     public function __toString()
     {
         return 'DocBlock Tag [ * @' . $this->getName() . ' ]' . "\n";

--- a/src/Reflection/DocBlock/Tag/ReturnTag.php
+++ b/src/Reflection/DocBlock/Tag/ReturnTag.php
@@ -15,14 +15,10 @@ use function trim;
 
 class ReturnTag implements TagInterface, PhpDocTypedTagInterface
 {
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $types = [];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $description;
 
     /**
@@ -52,8 +48,9 @@ class ReturnTag implements TagInterface, PhpDocTypedTagInterface
     }
 
     /**
-     * @return string
      * @deprecated 2.0.4 use getTypes instead
+     *
+     * @return string
      */
     public function getType()
     {
@@ -64,6 +61,7 @@ class ReturnTag implements TagInterface, PhpDocTypedTagInterface
         return $this->types[0];
     }
 
+    /** {@inheritDoc} */
     public function getTypes()
     {
         return $this->types;

--- a/src/Reflection/DocBlock/Tag/ThrowsTag.php
+++ b/src/Reflection/DocBlock/Tag/ThrowsTag.php
@@ -15,13 +15,12 @@ use function preg_match;
 class ThrowsTag implements TagInterface, PhpDocTypedTagInterface
 {
     /**
-     * @var array
+     * @var string[]
+     * @psalm-var list<string>
      */
     protected $types = [];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $description;
 
     /**
@@ -51,17 +50,16 @@ class ThrowsTag implements TagInterface, PhpDocTypedTagInterface
     /**
      * Get return variable type
      *
-     * @return string
      * @deprecated 2.0.4 use getTypes instead
+     *
+     * @return string
      */
     public function getType()
     {
         return implode('|', $this->getTypes());
     }
 
-    /**
-     * @return array
-     */
+    /** {@inheritDoc} */
     public function getTypes()
     {
         return $this->types;

--- a/src/Reflection/DocBlock/Tag/VarTag.php
+++ b/src/Reflection/DocBlock/Tag/VarTag.php
@@ -8,27 +8,30 @@
 
 namespace Laminas\Code\Reflection\DocBlock\Tag;
 
+use function explode;
+use function preg_match;
+use function rtrim;
+
+use const PHP_EOL;
+
 class VarTag implements TagInterface, PhpDocTypedTagInterface
 {
     /**
      * @var string[]
+     * @psalm-var list<string>
      */
     private $types = [];
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     private $variableName;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     private $description;
 
     /**
      * {@inheritDoc}
      */
-    public function getName() : string
+    public function getName(): string
     {
         return 'var';
     }
@@ -36,15 +39,17 @@ class VarTag implements TagInterface, PhpDocTypedTagInterface
     /**
      * {@inheritDoc}
      */
-    public function initialize($tagDocblockLine) : void
+    public function initialize($tagDocblockLine): void
     {
         $match = [];
 
-        if (! preg_match(
-            '#^([^\$]\S+)?\s*(\$[\S]+)?\s*(.*)$#m',
-            $tagDocblockLine,
-            $match
-        )) {
+        if (
+            ! preg_match(
+                '#^([^\$]\S+)?\s*(\$[\S]+)?\s*(.*)$#m',
+                $tagDocblockLine,
+                $match
+            )
+        ) {
             return;
         }
 
@@ -61,25 +66,26 @@ class VarTag implements TagInterface, PhpDocTypedTagInterface
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getTypes() : array
+    /** {@inheritDoc} */
+    public function getTypes(): array
     {
         return $this->types;
     }
 
-    public function getVariableName() : ?string
+    public function getVariableName(): ?string
     {
         return $this->variableName;
     }
 
-    public function getDescription() : ?string
+    public function getDescription(): ?string
     {
         return $this->description;
     }
 
-    public function __toString() : string
+    /**
+     * @psalm-return non-empty-string
+     */
+    public function __toString(): string
     {
         return 'DocBlock Tag [ * @' . $this->getName() . ' ]' . PHP_EOL;
     }

--- a/src/Reflection/DocBlock/TagManager.php
+++ b/src/Reflection/DocBlock/TagManager.php
@@ -36,7 +36,7 @@ class TagManager extends PrototypeClassFactory
      */
     public function createTag($tagName, $content = null)
     {
-        /* @var TagInterface $newTag */
+        /** @var TagInterface $newTag */
         $newTag = $this->getClonedPrototype($tagName);
 
         if ($content) {

--- a/src/Reflection/DocBlockReflection.php
+++ b/src/Reflection/DocBlockReflection.php
@@ -14,7 +14,6 @@ use Laminas\Code\Scanner\DocBlockScanner;
 use Reflector;
 
 use function count;
-use function get_class;
 use function is_string;
 use function ltrim;
 use function method_exists;
@@ -24,54 +23,34 @@ use function substr_count;
 
 class DocBlockReflection implements ReflectionInterface
 {
-    /**
-     * @var Reflector
-     */
+    /** @var Reflector */
     protected $reflector;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $docComment;
 
-    /**
-     * @var DocBlockTagManager
-     */
+    /** @var DocBlockTagManager */
     protected $tagManager;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $startLine;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $endLine;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $cleanDocComment;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $longDescription;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $shortDescription;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $tags = [];
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $isReflected = false;
 
     /**
@@ -88,10 +67,9 @@ class DocBlockReflection implements ReflectionInterface
 
     /**
      * @param  Reflector|string $commentOrReflector
-     * @param  null|DocBlockTagManager $tagManager
      * @throws Exception\InvalidArgumentException
      */
-    public function __construct($commentOrReflector, DocBlockTagManager $tagManager = null)
+    public function __construct($commentOrReflector, ?DocBlockTagManager $tagManager = null)
     {
         if (! $tagManager) {
             $tagManager = new DocBlockTagManager();
@@ -104,7 +82,7 @@ class DocBlockReflection implements ReflectionInterface
             if (! method_exists($commentOrReflector, 'getDocComment')) {
                 throw new Exception\InvalidArgumentException('Reflector must contain method "getDocComment"');
             }
-            /* @var MethodReflection $commentOrReflector */
+
             $this->docComment = $commentOrReflector->getDocComment();
 
             // determine line numbers
@@ -116,7 +94,7 @@ class DocBlockReflection implements ReflectionInterface
         } else {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s must have a (string) DocComment or a Reflector in the constructor',
-                get_class($this)
+                static::class
             ));
         }
 
@@ -281,7 +259,7 @@ class DocBlockReflection implements ReflectionInterface
      */
     public function toString()
     {
-        $str = 'DocBlock [ /* DocBlock */ ] {' . "\n\n";
+        $str  = 'DocBlock [ /* DocBlock */ ] {' . "\n\n";
         $str .= '  - Tags [' . count($this->tags) . '] {' . "\n";
 
         foreach ($this->tags as $tag) {

--- a/src/Reflection/FunctionReflection.php
+++ b/src/Reflection/FunctionReflection.php
@@ -24,17 +24,19 @@ use function strrpos;
 use function substr;
 use function var_export;
 
+use const FILE_IGNORE_NEW_LINES;
+
 class FunctionReflection extends ReflectionFunction implements ReflectionInterface
 {
     /**
      * Constant use in @MethodReflection to display prototype as an array
      */
-    const PROTOTYPE_AS_ARRAY = 'prototype_as_array';
+    public const PROTOTYPE_AS_ARRAY = 'prototype_as_array';
 
     /**
      * Constant use in @MethodReflection to display prototype as a string
      */
-    const PROTOTYPE_AS_STRING = 'prototype_as_string';
+    public const PROTOTYPE_AS_STRING = 'prototype_as_string';
 
     /**
      * Get function DocBlock
@@ -51,9 +53,7 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
             ));
         }
 
-        $instance = new DocBlockReflection($comment);
-
-        return $instance;
+        return new DocBlockReflection($comment);
     }
 
     /**
@@ -87,11 +87,11 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
         }
 
         $startLine = $this->getStartLine();
-        $endLine = $this->getEndLine();
+        $endLine   = $this->getEndLine();
 
         // eval'd protect
         if (preg_match('#\((\d+)\) : eval\(\)\'d code$#', $fileName, $matches)) {
-            $fileName = preg_replace('#\(\d+\) : eval\(\)\'d code$#', '', $fileName);
+            $fileName  = preg_replace('#\(\d+\) : eval\(\)\'d code$#', '', $fileName);
             $startLine = $endLine = $matches[1];
         }
 
@@ -133,14 +133,14 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
      * @param string $format
      * @return array|string
      */
-    public function getPrototype($format = FunctionReflection::PROTOTYPE_AS_ARRAY)
+    public function getPrototype($format = self::PROTOTYPE_AS_ARRAY)
     {
         $returnType = 'mixed';
-        $docBlock = $this->getDocBlock();
+        $docBlock   = $this->getDocBlock();
         if ($docBlock) {
-            $return = $docBlock->getTag('return');
+            $return      = $docBlock->getTag('return');
             $returnTypes = $return->getTypes();
-            $returnType = count($returnTypes) > 1 ? implode('|', $returnTypes) : $returnTypes[0];
+            $returnType  = count($returnTypes) > 1 ? implode('|', $returnTypes) : $returnTypes[0];
         }
 
         $prototype = [
@@ -160,7 +160,7 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
             ];
         }
 
-        if ($format == FunctionReflection::PROTOTYPE_AS_STRING) {
+        if ($format == self::PROTOTYPE_AS_STRING) {
             $line = $prototype['return'] . ' ' . $prototype['name'] . '(';
             $args = [];
             foreach ($prototype['arguments'] as $name => $argument) {
@@ -188,10 +188,10 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
      */
     public function getParameters()
     {
-        $phpReflections  = parent::getParameters();
+        $phpReflections     = parent::getParameters();
         $laminasReflections = [];
         while ($phpReflections && ($phpReflection = array_shift($phpReflections))) {
-            $instance          = new ParameterReflection($this->getName(), $phpReflection->getName());
+            $instance             = new ParameterReflection($this->getName(), $phpReflection->getName());
             $laminasReflections[] = $instance;
             unset($phpReflection);
         }
@@ -215,7 +215,7 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
             );
         }
 
-        $tag    = $docBlock->getTag('return');
+        $tag = $docBlock->getTag('return');
 
         return new DocBlockReflection('@return ' . $tag->getDescription());
     }
@@ -235,11 +235,11 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
         }
 
         $startLine = $this->getStartLine();
-        $endLine = $this->getEndLine();
+        $endLine   = $this->getEndLine();
 
         // eval'd protect
         if (preg_match('#\((\d+)\) : eval\(\)\'d code$#', $fileName, $matches)) {
-            $fileName = preg_replace('#\(\d+\) : eval\(\)\'d code$#', '', $fileName);
+            $fileName  = preg_replace('#\(\d+\) : eval\(\)\'d code$#', '', $fileName);
             $startLine = $endLine = $matches[1];
         }
 

--- a/src/Reflection/MethodReflection.php
+++ b/src/Reflection/MethodReflection.php
@@ -25,17 +25,19 @@ use function token_get_all;
 use function token_name;
 use function var_export;
 
+use const FILE_IGNORE_NEW_LINES;
+
 class MethodReflection extends PhpReflectionMethod implements ReflectionInterface
 {
     /**
      * Constant use in @MethodReflection to display prototype as an array
      */
-    const PROTOTYPE_AS_ARRAY = 'prototype_as_array';
+    public const PROTOTYPE_AS_ARRAY = 'prototype_as_array';
 
     /**
      * Constant use in @MethodReflection to display prototype as a string
      */
-    const PROTOTYPE_AS_STRING = 'prototype_as_string';
+    public const PROTOTYPE_AS_STRING = 'prototype_as_string';
 
     /**
      * Retrieve method DocBlock reflection
@@ -48,9 +50,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
             return false;
         }
 
-        $instance = new DocBlockReflection($this);
-
-        return $instance;
+        return new DocBlockReflection($this);
     }
 
     /**
@@ -77,7 +77,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
      */
     public function getDeclaringClass()
     {
-        $phpReflection  = parent::getDeclaringClass();
+        $phpReflection     = parent::getDeclaringClass();
         $laminasReflection = new ClassReflection($phpReflection->getName());
         unset($phpReflection);
 
@@ -90,18 +90,18 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
      * @param string $format
      * @return array|string
      */
-    public function getPrototype($format = MethodReflection::PROTOTYPE_AS_ARRAY)
+    public function getPrototype($format = self::PROTOTYPE_AS_ARRAY)
     {
         $returnType = 'mixed';
-        $docBlock = $this->getDocBlock();
+        $docBlock   = $this->getDocBlock();
         if ($docBlock) {
-            $return = $docBlock->getTag('return');
+            $return      = $docBlock->getTag('return');
             $returnTypes = $return->getTypes();
-            $returnType = count($returnTypes) > 1 ? implode('|', $returnTypes) : $returnTypes[0];
+            $returnType  = count($returnTypes) > 1 ? implode('|', $returnTypes) : $returnTypes[0];
         }
 
         $declaringClass = $this->getDeclaringClass();
-        $prototype = [
+        $prototype      = [
             'namespace'  => $declaringClass->getNamespaceName(),
             'class'      => substr($declaringClass->getName(), strlen($declaringClass->getNamespaceName()) + 1),
             'name'       => $this->getName(),
@@ -120,7 +120,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
             ];
         }
 
-        if ($format == MethodReflection::PROTOTYPE_AS_STRING) {
+        if ($format == self::PROTOTYPE_AS_STRING) {
             $line = $prototype['visibility'] . ' ' . $prototype['return'] . ' ' . $prototype['name'] . '(';
             $args = [];
             foreach ($prototype['arguments'] as $name => $argument) {
@@ -148,10 +148,10 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
      */
     public function getParameters()
     {
-        $phpReflections  = parent::getParameters();
+        $phpReflections     = parent::getParameters();
         $laminasReflections = [];
         while ($phpReflections && ($phpReflection = array_shift($phpReflections))) {
-            $instance = new ParameterReflection(
+            $instance             = new ParameterReflection(
                 [$this->getDeclaringClass()->getName(), $this->getName()],
                 $phpReflection->getName()
             );
@@ -172,8 +172,8 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
     public function getContents($includeDocBlock = true)
     {
         $docComment = $this->getDocComment();
-        $content  = $includeDocBlock && ! empty($docComment) ? $docComment . "\n" : '';
-        $content .= $this->extractMethodContents();
+        $content    = $includeDocBlock && ! empty($docComment) ? $docComment . "\n" : '';
+        $content   .= $this->extractMethodContents();
 
         return $content;
     }
@@ -210,7 +210,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
         );
 
         $functionLine = implode("\n", $lines);
-        $tokens = token_get_all('<?php ' . $functionLine);
+        $tokens       = token_get_all('<?php ' . $functionLine);
 
         //remove first entry which is php open tag
         array_shift($tokens);
@@ -219,9 +219,9 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
             return '';
         }
 
-        $capture = false;
+        $capture    = false;
         $firstBrace = false;
-        $body = '';
+        $body       = '';
 
         foreach ($tokens as $key => $token) {
             $tokenType  = is_array($token) ? token_name($token[0]) : $token;
@@ -321,13 +321,13 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
     protected function extractPrefixedWhitespace($haystack, $position)
     {
         $content = '';
-        $count = count($haystack);
+        $count   = count($haystack);
         if ($position + 1 == $count) {
             return $content;
         }
 
         for ($i = $position - 1; $i >= 0; $i--) {
-            $tokenType = is_array($haystack[$i]) ? token_name($haystack[$i][0]) : $haystack[$i];
+            $tokenType  = is_array($haystack[$i]) ? token_name($haystack[$i][0]) : $haystack[$i];
             $tokenValue = is_array($haystack[$i]) ? $haystack[$i][1] : $haystack[$i];
 
             //search only for whitespace
@@ -353,7 +353,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
         $count = count($haystack);
 
         //advance one position
-        $position = $position + 1;
+        $position += 1;
 
         if ($position == $count) {
             return true;
@@ -420,9 +420,9 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
     protected function isValidFunction($haystack, $position, $functionName = null)
     {
         $isValid = false;
-        $count = count($haystack);
+        $count   = count($haystack);
         for ($i = $position + 1; $i < $count; $i++) {
-            $tokenType = is_array($haystack[$i]) ? token_name($haystack[$i][0]) : $haystack[$i];
+            $tokenType  = is_array($haystack[$i]) ? token_name($haystack[$i][0]) : $haystack[$i];
             $tokenValue = is_array($haystack[$i]) ? $haystack[$i][1] : $haystack[$i];
 
             //check for occurrence of ( or

--- a/src/Reflection/ParameterReflection.php
+++ b/src/Reflection/ParameterReflection.php
@@ -8,15 +8,15 @@
 
 namespace Laminas\Code\Reflection;
 
+use ReflectionClass;
+use ReflectionMethod;
 use ReflectionParameter;
 
 use function method_exists;
 
 class ParameterReflection extends ReflectionParameter implements ReflectionInterface
 {
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $isFromMethod = false;
 
     /**
@@ -26,7 +26,7 @@ class ParameterReflection extends ReflectionParameter implements ReflectionInter
      */
     public function getDeclaringClass()
     {
-        $phpReflection  = parent::getDeclaringClass();
+        $phpReflection     = parent::getDeclaringClass();
         $laminasReflection = new ClassReflection($phpReflection->getName());
         unset($phpReflection);
 
@@ -59,7 +59,7 @@ class ParameterReflection extends ReflectionParameter implements ReflectionInter
     public function getDeclaringFunction()
     {
         $phpReflection = parent::getDeclaringFunction();
-        if ($phpReflection instanceof \ReflectionMethod) {
+        if ($phpReflection instanceof ReflectionMethod) {
             $laminasReflection = new MethodReflection($this->getDeclaringClass()->getName(), $phpReflection->getName());
         } else {
             $laminasReflection = new FunctionReflection($phpReflection->getName());
@@ -76,7 +76,8 @@ class ParameterReflection extends ReflectionParameter implements ReflectionInter
      */
     public function detectType()
     {
-        if (method_exists($this, 'getType')
+        if (
+            method_exists($this, 'getType')
             && null !== ($type = $this->getType())
             && $type->isBuiltin()
         ) {
@@ -87,7 +88,7 @@ class ParameterReflection extends ReflectionParameter implements ReflectionInter
             return $this->getDeclaringClass()->getName();
         }
 
-        if (($class = $this->getClass()) instanceof \ReflectionClass) {
+        if (($class = $this->getClass()) instanceof ReflectionClass) {
             return $class->getName();
         }
 

--- a/src/Reflection/PropertyReflection.php
+++ b/src/Reflection/PropertyReflection.php
@@ -22,7 +22,7 @@ class PropertyReflection extends PhpReflectionProperty implements ReflectionInte
      */
     public function getDeclaringClass()
     {
-        $phpReflection  = parent::getDeclaringClass();
+        $phpReflection     = parent::getDeclaringClass();
         $laminasReflection = new ClassReflection($phpReflection->getName());
         unset($phpReflection);
 
@@ -48,9 +48,7 @@ class PropertyReflection extends PhpReflectionProperty implements ReflectionInte
             return false;
         }
 
-        $docBlockReflection = new DocBlockReflection($docComment);
-
-        return $docBlockReflection;
+        return new DocBlockReflection($docComment);
     }
 
     /**

--- a/src/Scanner/DocBlockScanner.php
+++ b/src/Scanner/DocBlockScanner.php
@@ -24,29 +24,19 @@ use function trim;
 /** @internal this class is not part of the public API of this package */
 class DocBlockScanner
 {
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $isScanned = false;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $docComment;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $shortDescription;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $longDescription = '';
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $tags = [];
 
     /**
@@ -54,7 +44,7 @@ class DocBlockScanner
      */
     public function __construct($docComment)
     {
-        $this->docComment      = $docComment;
+        $this->docComment = $docComment;
     }
 
     /**
@@ -176,7 +166,7 @@ class DocBlockScanner
         $currentWord = null;
         $currentLine = null;
 
-        $MACRO_STREAM_ADVANCE_CHAR = function ($positionsForward = 1) use (
+        $MACRO_STREAM_ADVANCE_CHAR       = function ($positionsForward = 1) use (
             &$stream,
             &$streamIndex,
             &$currentChar,

--- a/test/Generator/AbstractMemberGeneratorTest.php
+++ b/test/Generator/AbstractMemberGeneratorTest.php
@@ -12,15 +12,14 @@ use Laminas\Code\Generator\AbstractMemberGenerator;
 use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class AbstractMemberGeneratorTest extends TestCase
 {
-    /**
-     * @var AbstractMemberGenerator
-     */
+    /** @var AbstractMemberGenerator */
     private $fixture;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->fixture = $this->getMockForAbstractClass(AbstractMemberGenerator::class);
     }
@@ -41,7 +40,7 @@ class AbstractMemberGeneratorTest extends TestCase
     public function testSetDocBlockThrowsExceptionWithInvalidType()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->fixture->setDocBlock(new \stdClass());
+        $this->fixture->setDocBlock(new stdClass());
     }
 
     public function testRemoveDocBlock(): void

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -20,6 +20,7 @@ use Laminas\Code\Reflection\ClassReflection;
 use LaminasTest\Code\TestAsset\FooClass;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
+use stdClass;
 
 use function current;
 use function fclose;
@@ -48,7 +49,7 @@ class ClassGeneratorTest extends TestCase
     public function testClassDocBlockAccessors()
     {
         $docBlockGenerator = new DocBlockGenerator();
-        $classGenerator = new ClassGenerator();
+        $classGenerator    = new ClassGenerator();
         $classGenerator->setDocBlock($docBlockGenerator);
         self::assertSame($docBlockGenerator, $classGenerator->getDocBlock());
     }
@@ -245,15 +246,15 @@ class ClassGeneratorTest extends TestCase
     public function testToString()
     {
         $classGenerator = ClassGenerator::fromArray([
-            'name' => 'SampleClass',
-            'flags' => ClassGenerator::FLAG_ABSTRACT,
-            'extendedClass' => 'ExtendedClassName',
+            'name'                  => 'SampleClass',
+            'flags'                 => ClassGenerator::FLAG_ABSTRACT,
+            'extendedClass'         => 'ExtendedClassName',
             'implementedInterfaces' => ['Iterator', 'Traversable'],
-            'properties' => [
+            'properties'            => [
                 'foo',
                 ['name' => 'bar'],
             ],
-            'methods' => [
+            'methods'               => [
                 ['name' => 'baz'],
             ],
         ]);
@@ -319,7 +320,7 @@ EOS;
     {
         require_once __DIR__ . '/../TestAsset/NonNamespaceClass.php';
 
-        $reflClass = new ClassReflection('LaminasTest_Code_NsTest_BarClass');
+        $reflClass      = new ClassReflection('LaminasTest_Code_NsTest_BarClass');
         $classGenerator = ClassGenerator::fromReflection($reflClass);
         self::assertCount(1, $classGenerator->getMethods());
     }
@@ -367,7 +368,7 @@ CODE;
      */
     public function testCodeGenerationShouldTakeIntoAccountNamespacesFromReflection()
     {
-        $reflClass = new ClassReflection(TestAsset\ClassWithNamespace::class);
+        $reflClass      = new ClassReflection(TestAsset\ClassWithNamespace::class);
         $classGenerator = ClassGenerator::fromReflection($reflClass);
         self::assertEquals('LaminasTest\Code\Generator\TestAsset', $classGenerator->getNamespaceName());
         self::assertEquals('ClassWithNamespace', $classGenerator->getName());
@@ -507,7 +508,7 @@ CODE;
     public function testCreateFromArrayWithDocBlockFromArray()
     {
         $classGenerator = ClassGenerator::fromArray([
-            'name' => 'SampleClass',
+            'name'     => 'SampleClass',
             'docblock' => [
                 'shortdescription' => 'foo',
             ],
@@ -520,7 +521,7 @@ CODE;
     public function testCreateFromArrayWithDocBlockInstance()
     {
         $classGenerator = ClassGenerator::fromArray([
-            'name' => 'SampleClass',
+            'name'     => 'SampleClass',
             'docblock' => new DocBlockGenerator('foo'),
         ]);
 
@@ -530,9 +531,9 @@ CODE;
 
     public function testExtendedClassProperies()
     {
-        $reflClass = new ClassReflection(TestAsset\ExtendedClassWithProperties::class);
+        $reflClass      = new ClassReflection(TestAsset\ExtendedClassWithProperties::class);
         $classGenerator = ClassGenerator::fromReflection($reflClass);
-        $code = $classGenerator->generate();
+        $code           = $classGenerator->generate();
         self::assertStringContainsString('publicExtendedClassProperty', $code);
         self::assertStringContainsString('protectedExtendedClassProperty', $code);
         self::assertStringContainsString('privateExtendedClassProperty', $code);
@@ -677,7 +678,7 @@ CODE;
         $classGenerator = new ClassGenerator();
 
         $this->expectException(InvalidArgumentException::class);
-        $classGenerator->addConstant('a', new \stdClass());
+        $classGenerator->addConstant('a', new stdClass());
     }
 
     public function testAddConstantRejectsResourceConstantValue()
@@ -702,7 +703,7 @@ CODE;
         $classGenerator = new ClassGenerator();
 
         $this->expectException(InvalidArgumentException::class);
-        $classGenerator->addConstant('a', [new \stdClass()]);
+        $classGenerator->addConstant('a', [new stdClass()]);
     }
 
     /**
@@ -744,7 +745,7 @@ CODE;
      */
     public function testAddPropertiesIsBackwardsCompatibleWithConstants()
     {
-        $constants = [
+        $constants      = [
             new PropertyGenerator('x', 'value1', PropertyGenerator::FLAG_CONSTANT),
             new PropertyGenerator('y', 'value2', PropertyGenerator::FLAG_CONSTANT),
         ];
@@ -824,9 +825,9 @@ CODE;
      */
     public function testHereDoc()
     {
-        $reflector = new ClassReflection(TestAsset\TestClassWithHeredoc::class);
+        $reflector      = new ClassReflection(TestAsset\TestClassWithHeredoc::class);
         $classGenerator = new ClassGenerator();
-        $methods = $reflector->getMethods();
+        $methods        = $reflector->getMethods();
         $classGenerator->setName('OutputClass');
 
         foreach ($methods as $method) {
@@ -835,7 +836,7 @@ CODE;
             $classGenerator->addMethodFromGenerator($methodGenerator);
         }
 
-        $contents = <<< 'CODE'
+        $contents = <<<'CODE'
 class OutputClass
 {
     public function someFunction()
@@ -1136,7 +1137,7 @@ CODE;
     public function testGenerateWithFinalFlag()
     {
         $classGenerator = ClassGenerator::fromArray([
-            'name' => 'SomeClass',
+            'name'  => 'SomeClass',
             'flags' => ClassGenerator::FLAG_FINAL,
         ]);
 
@@ -1252,9 +1253,9 @@ EOS;
         $classGenerator->setNamespaceName('SomeNamespace');
         $classGenerator->addUse(GeneratorInterface::class);
         $classGenerator->setImplementedInterfaces([
-           'SomeNamespace\ClassInterface',
-           GeneratorInterface::class,
-           'Iteratable',
+            'SomeNamespace\ClassInterface',
+            GeneratorInterface::class,
+            'Iteratable',
         ]);
 
         $expected = 'class ClassName implements ClassInterface, GeneratorInterface, \Iteratable';

--- a/test/Generator/DocBlock/Tag/AuthorTagTest.php
+++ b/test/Generator/DocBlock/Tag/AuthorTagTest.php
@@ -19,26 +19,22 @@ use PHPUnit\Framework\TestCase;
  */
 class AuthorTagTest extends TestCase
 {
-    /**
-     * @var AuthorTag
-     */
+    /** @var AuthorTag */
     protected $tag;
 
-    /**
-     * @var TagManager
-     */
+    /** @var TagManager */
     protected $tagmanager;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->tag = new AuthorTag();
+        $this->tag        = new AuthorTag();
         $this->tagmanager = new TagManager();
         $this->tagmanager->initializeDefaultTags();
     }
 
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
-        $this->tag = null;
+        $this->tag        = null;
         $this->tagmanager = null;
     }
 
@@ -66,7 +62,7 @@ class AuthorTagTest extends TestCase
     {
         $this->tag->setOptions([
             'authorEmail' => 'string',
-            'authorName' => 'foo',
+            'authorName'  => 'foo',
         ]);
         $tagWithOptionsFromConstructor = new AuthorTag('foo', 'string');
         self::assertEquals($this->tag->generate(), $tagWithOptionsFromConstructor->generate());

--- a/test/Generator/DocBlock/Tag/GenericTagTest.php
+++ b/test/Generator/DocBlock/Tag/GenericTagTest.php
@@ -19,26 +19,22 @@ use PHPUnit\Framework\TestCase;
  */
 class GenericTagTest extends TestCase
 {
-    /**
-     * @var GenericTag
-     */
+    /** @var GenericTag */
     protected $tag;
 
-    /**
-     * @var TagManager
-     */
+    /** @var TagManager */
     protected $tagmanager;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->tag = new GenericTag();
+        $this->tag        = new GenericTag();
         $this->tagmanager = new TagManager();
         $this->tagmanager->initializeDefaultTags();
     }
 
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
-        $this->tag = null;
+        $this->tag        = null;
         $this->tagmanager = null;
     }
 
@@ -60,7 +56,7 @@ class GenericTagTest extends TestCase
     public function testConstructorWithOptions()
     {
         $this->tag->setOptions([
-            'name' => 'var',
+            'name'    => 'var',
             'content' => 'string',
         ]);
         $tagWithOptionsFromConstructor = new GenericTag('var', 'string');

--- a/test/Generator/DocBlock/Tag/LicenseTagTest.php
+++ b/test/Generator/DocBlock/Tag/LicenseTagTest.php
@@ -19,26 +19,22 @@ use PHPUnit\Framework\TestCase;
  */
 class LicenseTagTest extends TestCase
 {
-    /**
-     * @var LicenseTag
-     */
+    /** @var LicenseTag */
     protected $tag;
 
-    /**
-     * @var TagManager
-     */
+    /** @var TagManager */
     protected $tagmanager;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->tag = new LicenseTag();
+        $this->tag        = new LicenseTag();
         $this->tagmanager = new TagManager();
         $this->tagmanager->initializeDefaultTags();
     }
 
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
-        $this->tag = null;
+        $this->tag        = null;
         $this->tagmanager = null;
     }
 
@@ -66,7 +62,7 @@ class LicenseTagTest extends TestCase
     public function testConstructorWithOptions()
     {
         $this->tag->setOptions([
-            'url' => 'foo',
+            'url'         => 'foo',
             'licenseName' => 'bar',
         ]);
         $tagWithOptionsFromConstructor = new LicenseTag('foo', 'bar');

--- a/test/Generator/DocBlock/Tag/MethodTagTest.php
+++ b/test/Generator/DocBlock/Tag/MethodTagTest.php
@@ -19,26 +19,22 @@ use PHPUnit\Framework\TestCase;
  */
 class MethodTagTest extends TestCase
 {
-    /**
-     * @var MethodTag
-     */
+    /** @var MethodTag */
     protected $tag;
 
-    /**
-     * @var TagManager
-     */
+    /** @var TagManager */
     protected $tagmanager;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->tag = new MethodTag();
+        $this->tag        = new MethodTag();
         $this->tagmanager = new TagManager();
         $this->tagmanager->initializeDefaultTags();
     }
 
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
-        $this->tag = null;
+        $this->tag        = null;
         $this->tagmanager = null;
     }
 
@@ -73,9 +69,9 @@ class MethodTagTest extends TestCase
     public function testConstructorWithOptions()
     {
         $this->tag->setOptions([
-            'isStatic' => true,
-            'methodName' => 'method',
-            'types' => ['string'],
+            'isStatic'    => true,
+            'methodName'  => 'method',
+            'types'       => ['string'],
             'description' => 'description',
         ]);
         $tagWithOptionsFromConstructor = new MethodTag('method', ['string'], 'description', true);

--- a/test/Generator/DocBlock/Tag/ParamTagTest.php
+++ b/test/Generator/DocBlock/Tag/ParamTagTest.php
@@ -19,26 +19,22 @@ use PHPUnit\Framework\TestCase;
  */
 class ParamTagTest extends TestCase
 {
-    /**
-     * @var ParamTag
-     */
+    /** @var ParamTag */
     protected $tag;
 
-    /**
-     * @var TagManager
-     */
+    /** @var TagManager */
     protected $tagmanager;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->tag = new ParamTag();
+        $this->tag        = new ParamTag();
         $this->tagmanager = new TagManager();
         $this->tagmanager->initializeDefaultTags();
     }
 
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
-        $this->tag = null;
+        $this->tag        = null;
         $this->tagmanager = null;
     }
 
@@ -71,8 +67,8 @@ class ParamTagTest extends TestCase
     {
         $this->tag->setOptions([
             'variableName' => 'foo',
-            'types' => ['string'],
-            'description' => 'description',
+            'types'        => ['string'],
+            'description'  => 'description',
         ]);
         $tagWithOptionsFromConstructor = new ParamTag('foo', ['string'], 'description');
         self::assertEquals($this->tag->generate(), $tagWithOptionsFromConstructor->generate());

--- a/test/Generator/DocBlock/Tag/PropertyTagTest.php
+++ b/test/Generator/DocBlock/Tag/PropertyTagTest.php
@@ -19,26 +19,22 @@ use PHPUnit\Framework\TestCase;
  */
 class PropertyTagTest extends TestCase
 {
-    /**
-     * @var PropertyTag
-     */
+    /** @var PropertyTag */
     protected $tag;
 
-    /**
-     * @var TagManager
-     */
+    /** @var TagManager */
     protected $tagmanager;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->tag = new PropertyTag();
+        $this->tag        = new PropertyTag();
         $this->tagmanager = new TagManager();
         $this->tagmanager->initializeDefaultTags();
     }
 
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
-        $this->tag = null;
+        $this->tag        = null;
         $this->tagmanager = null;
     }
 
@@ -71,8 +67,8 @@ class PropertyTagTest extends TestCase
     {
         $this->tag->setOptions([
             'propertyName' => 'property',
-            'types' => ['string'],
-            'description' => 'description',
+            'types'        => ['string'],
+            'description'  => 'description',
         ]);
         $tagWithOptionsFromConstructor = new PropertyTag('property', ['string'], 'description');
         self::assertEquals($this->tag->generate(), $tagWithOptionsFromConstructor->generate());

--- a/test/Generator/DocBlock/Tag/ReturnTagTest.php
+++ b/test/Generator/DocBlock/Tag/ReturnTagTest.php
@@ -19,26 +19,22 @@ use PHPUnit\Framework\TestCase;
  */
 class ReturnTagTest extends TestCase
 {
-    /**
-     * @var ReturnTag
-     */
+    /** @var ReturnTag */
     protected $tag;
 
-    /**
-     * @var TagManager
-     */
+    /** @var TagManager */
     protected $tagmanager;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->tag = new ReturnTag();
+        $this->tag        = new ReturnTag();
         $this->tagmanager = new TagManager();
         $this->tagmanager->initializeDefaultTags();
     }
 
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
-        $this->tag = null;
+        $this->tag        = null;
         $this->tagmanager = null;
     }
 

--- a/test/Generator/DocBlock/Tag/ThrowsTagTest.php
+++ b/test/Generator/DocBlock/Tag/ThrowsTagTest.php
@@ -19,26 +19,22 @@ use PHPUnit\Framework\TestCase;
  */
 class ThrowsTagTest extends TestCase
 {
-    /**
-     * @var ThrowsTag
-     */
+    /** @var ThrowsTag */
     protected $tag;
 
-    /**
-     * @var TagManager
-     */
+    /** @var TagManager */
     protected $tagmanager;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->tag = new ThrowsTag();
+        $this->tag        = new ThrowsTag();
         $this->tagmanager = new TagManager();
         $this->tagmanager->initializeDefaultTags();
     }
 
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
-        $this->tag = null;
+        $this->tag        = null;
         $this->tagmanager = null;
     }
 

--- a/test/Generator/DocBlock/Tag/TypableTagTest.php
+++ b/test/Generator/DocBlock/Tag/TypableTagTest.php
@@ -17,17 +17,15 @@ use PHPUnit\Framework\TestCase;
  */
 class TypableTagTest extends TestCase
 {
-    /**
-     * @var TypeableTag
-     */
+    /** @var TypeableTag */
     protected $tag;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->tag = new TypeableTag();
     }
 
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
         $this->tag = null;
     }
@@ -67,7 +65,7 @@ class TypableTagTest extends TestCase
     public function testConstructorWithOptions()
     {
         $this->tag->setOptions([
-            'types' => ['string', 'null'],
+            'types'       => ['string', 'null'],
             'description' => 'description',
         ]);
         $tagWithOptionsFromConstructor = new TypeableTag(['string', 'null'], 'description');

--- a/test/Generator/DocBlock/Tag/VarTagTest.php
+++ b/test/Generator/DocBlock/Tag/VarTagTest.php
@@ -19,17 +19,13 @@ use PHPUnit\Framework\TestCase;
  */
 class VarTagTest extends TestCase
 {
-    /**
-     * @var VarTag
-     */
+    /** @var VarTag */
     private $tag;
 
-    /**
-     * @var TagManager
-     */
+    /** @var TagManager */
     private $tagManager;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -39,25 +35,25 @@ class VarTagTest extends TestCase
         $this->tagManager->initializeDefaultTags();
     }
 
-    public function testGetterAndSetterPersistValue() : void
+    public function testGetterAndSetterPersistValue(): void
     {
         $tag = new VarTag('variable');
 
         self::assertSame('variable', $tag->getVariableName());
     }
 
-    public function testGetterForVariableNameTrimsCorrectly() : void
+    public function testGetterForVariableNameTrimsCorrectly(): void
     {
         $this->tag->setVariableName('$variable$');
         $this->assertEquals('variable$', $this->tag->getVariableName());
     }
 
-    public function testNameIsCorrect() : void
+    public function testNameIsCorrect(): void
     {
         $this->assertEquals('var', $this->tag->getName());
     }
 
-    public function testParamProducesCorrectDocBlockLine() : void
+    public function testParamProducesCorrectDocBlockLine(): void
     {
         $this->tag->setVariableName('variable');
         $this->tag->setTypes('string[]');
@@ -65,7 +61,7 @@ class VarTagTest extends TestCase
         $this->assertEquals('@var string[] $variable description', $this->tag->generate());
     }
 
-    public function testConstructorWithOptions() : void
+    public function testConstructorWithOptions(): void
     {
         $this->tag->setOptions([
             'variableName' => 'foo',
@@ -76,7 +72,7 @@ class VarTagTest extends TestCase
         $this->assertEquals($this->tag->generate(), $tagWithOptionsFromConstructor->generate());
     }
 
-    public function testCreatingTagFromReflection() : void
+    public function testCreatingTagFromReflection(): void
     {
         $reflectionTag = (new DocBlockReflection('/** @var int $foo description'))
             ->getTag('var');

--- a/test/Generator/DocBlockGeneratorTest.php
+++ b/test/Generator/DocBlockGeneratorTest.php
@@ -23,20 +23,16 @@ use PHPUnit\Framework\TestCase;
  */
 class DocBlockGeneratorTest extends TestCase
 {
-    /**
-     * @var DocBlockGenerator
-     */
+    /** @var DocBlockGenerator */
     protected $docBlockGenerator;
 
-    /**
-     * @var DocBlockGenerator
-     */
+    /** @var DocBlockGenerator */
     protected $reflectionDocBlockGenerator;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->docBlockGenerator = $this->docBlockGenerator = new DocBlockGenerator();
-        $reflectionDocBlock = new DocBlockReflection(
+        $reflectionDocBlock      = new DocBlockReflection(
             '/**
  * Short Description
  * Long Description
@@ -113,7 +109,7 @@ EOS;
         $docBlock = DocBlockGenerator::fromArray([
             'shortdescription' => 'foo',
             'longdescription'  => 'bar',
-            'tags' => [
+            'tags'             => [
                 [
                     'name'        => 'foo',
                     'description' => 'bar',

--- a/test/Generator/FileGeneratorTest.php
+++ b/test/Generator/FileGeneratorTest.php
@@ -14,17 +14,15 @@ use Laminas\Code\Generator\ClassGenerator;
 use Laminas\Code\Generator\Exception\ClassNotFoundException;
 use Laminas\Code\Generator\FileGenerator;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 use function explode;
 use function file_get_contents;
-use function file_put_contents;
 use function get_class;
 use function strlen;
 use function strpos;
 use function strrpos;
 use function sys_get_temp_dir;
-use function tempnam;
-use function unlink;
 
 /**
  * @group Laminas_Code_Generator
@@ -57,10 +55,10 @@ class FileGeneratorTest extends TestCase
     {
         $codeGenFile = FileGenerator::fromArray([
             'requiredFiles' => ['SampleClass.php'],
-            'class' => [
-                'flags' => ClassGenerator::FLAG_ABSTRACT,
-                'name' => 'SampleClass',
-                'extendedClass' => 'ExtendedClassName',
+            'class'         => [
+                'flags'                 => ClassGenerator::FLAG_ABSTRACT,
+                'name'                  => 'SampleClass',
+                'extendedClass'         => 'ExtendedClassName',
                 'implementedInterfaces' => ['Iterator', 'Traversable'],
             ],
         ]);
@@ -101,10 +99,10 @@ EOS;
     {
         $codeGenFile = FileGenerator::fromArray([
             'requiredFiles' => ['SampleClass.php'],
-            'class' => [
-                'abstract' => true,
-                'name' => 'SampleClass',
-                'extendedClass' => 'ExtendedClassName',
+            'class'         => [
+                'abstract'              => true,
+                'name'                  => 'SampleClass',
+                'extendedClass'         => 'ExtendedClassName',
                 'implementedInterfaces' => ['Iterator', 'Traversable'],
             ],
         ]);
@@ -217,22 +215,22 @@ EOS;
     public function testCreateFromArrayWithClassInstance()
     {
         $fileGenerator = FileGenerator::fromArray([
-            'filename'  => 'foo.php',
-            'class'     => new ClassGenerator('bar'),
+            'filename' => 'foo.php',
+            'class'    => new ClassGenerator('bar'),
         ]);
-        $class = $fileGenerator->getClass('bar');
+        $class         = $fileGenerator->getClass('bar');
         self::assertInstanceOf(ClassGenerator::class, $class);
     }
 
     public function testCreateFromArrayWithClassFromArray()
     {
         $fileGenerator = FileGenerator::fromArray([
-            'filename'  => 'foo.php',
-            'class'     => [
+            'filename' => 'foo.php',
+            'class'    => [
                 'name' => 'bar',
             ],
         ]);
-        $class = $fileGenerator->getClass('bar');
+        $class         = $fileGenerator->getClass('bar');
         self::assertInstanceOf(ClassGenerator::class, $class);
     }
 
@@ -242,7 +240,7 @@ EOS;
             'declares' => [
                 'strict_types' => 1,
             ],
-            'class' => [
+            'class'    => [
                 'name' => 'SampleClass',
             ],
         ]);
@@ -270,9 +268,9 @@ EOS;
         $generator = FileGenerator::fromArray([
             'declares' => [
                 'strict_types' => 1,
-                'ticks' => 2,
+                'ticks'        => 2,
             ],
-            'class' => [
+            'class'    => [
                 'name' => 'SampleClass',
             ],
         ]);
@@ -305,7 +303,7 @@ EOS;
             'declares' => [
                 'fubar' => 1,
             ],
-            'class' => [
+            'class'    => [
                 'name' => 'SampleClass',
             ],
         ]);
@@ -320,7 +318,7 @@ EOS;
             'declares' => [
                 'strict_types' => 'wrong type',
             ],
-            'class' => [
+            'class'    => [
                 'name' => 'SampleClass',
             ],
         ]);
@@ -336,7 +334,7 @@ EOS;
         $generator->setFilename(sys_get_temp_dir() . '/result_file.php');
         $generator->setDeclares([
             DeclareStatement::strictTypes(1),
-            DeclareStatement::strictTypes(2)
+            DeclareStatement::strictTypes(2),
         ]);
         $generator->write();
 
@@ -362,7 +360,7 @@ EOS;
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('setDeclares is expecting an array of Laminas\\Code\\DeclareStatement objects');
-        $generator->setDeclares([new \stdClass()]);
+        $generator->setDeclares([new stdClass()]);
     }
 
     /** @group gh-42 */
@@ -372,7 +370,7 @@ EOS;
 
         $generator->setNamespace('Foo');
         $generator->setDeclares([
-            DeclareStatement::strictTypes(1)
+            DeclareStatement::strictTypes(1),
         ]);
 
         self::assertStringMatchesFormat('%Adeclare(strict_types=1);%Anamespace Foo;%A', $generator->generate());

--- a/test/Generator/InterfaceGeneratorTest.php
+++ b/test/Generator/InterfaceGeneratorTest.php
@@ -81,7 +81,7 @@ class InterfaceGeneratorTest extends TestCase
     public function testToString()
     {
         $classGenerator = InterfaceGenerator::fromArray([
-            'name' => 'SampleInterface',
+            'name'    => 'SampleInterface',
             'methods' => [
                 ['name' => 'baz'],
             ],
@@ -192,7 +192,7 @@ CODE;
     public function testCreateFromArrayWithDocBlockFromArray()
     {
         $classGenerator = InterfaceGenerator::fromArray([
-            'name' => 'SampleClass',
+            'name'     => 'SampleClass',
             'docblock' => [
                 'shortdescription' => 'foo',
             ],
@@ -205,7 +205,7 @@ CODE;
     public function testCreateFromArrayWithDocBlockInstance()
     {
         $classGenerator = InterfaceGenerator::fromArray([
-            'name' => 'MyInterface',
+            'name'     => 'MyInterface',
             'docblock' => new DocBlockGenerator('foo'),
         ]);
 
@@ -268,6 +268,6 @@ CODE;
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Class LaminasTest\Code\Generator\InterfaceGeneratorTest is not a interface');
-        InterfaceGenerator::fromReflection(new ClassReflection(__CLASS__));
+        InterfaceGenerator::fromReflection(new ClassReflection(self::class));
     }
 }

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -28,7 +28,9 @@ use stdClass;
 
 use function array_filter;
 use function array_shift;
-use function strpos;
+use function array_values;
+
+use const PHP_VERSION_ID;
 
 /**
  * @group Laminas_Code_Generator
@@ -47,7 +49,7 @@ class MethodGeneratorTest extends TestCase
         $methodGenerator = new MethodGenerator();
         $methodGenerator->setParameters(['one']);
         $params = $methodGenerator->getParameters();
-        $param = array_shift($params);
+        $param  = array_shift($params);
         self::assertInstanceOf(ParameterGenerator::class, $param);
     }
 
@@ -62,7 +64,7 @@ class MethodGeneratorTest extends TestCase
         $params = $methodGenerator->getParameters();
         self::assertCount(3, $params);
 
-        /** @var $foo ParameterGenerator */
+        /** @var ParameterGenerator $foo */
         $foo = array_shift($params);
         self::assertInstanceOf(ParameterGenerator::class, $foo);
         self::assertEquals('foo', $foo->getName());
@@ -70,7 +72,7 @@ class MethodGeneratorTest extends TestCase
         $bar = array_shift($params);
         self::assertEquals(ParameterGenerator::fromArray(['name' => 'bar', 'type' => 'array']), $bar);
 
-        /** @var $baz ParameterGenerator */
+        /** @var ParameterGenerator $baz */
         $baz = array_shift($params);
         self::assertEquals('baz', $baz->getName());
 
@@ -99,7 +101,7 @@ class MethodGeneratorTest extends TestCase
         $ref = new MethodReflection(TestAsset\TestSampleSingleClass::class, 'withParamsAndReturnType');
 
         $methodGenerator = MethodGenerator::copyMethodSignature($ref);
-        $target = <<<'EOS'
+        $target          = <<<'EOS'
     protected function withParamsAndReturnType($mixed, array $array, ?callable $callable = null, ?int $int = 0) : bool
     {
     }
@@ -113,7 +115,7 @@ EOS;
         $ref = new MethodReflection(TestAsset\TestSampleSingleClass::class, 'someMethod');
 
         $methodGenerator = MethodGenerator::fromReflection($ref);
-        $target = <<<EOS
+        $target          = <<<EOS
     /**
      * Enter description here...
      *
@@ -133,7 +135,7 @@ EOS;
         $ref = new MethodReflection(TestAsset\TestSampleSingleClassMultiLines::class, 'someMethod');
 
         $methodGenerator = MethodGenerator::fromReflection($ref);
-        $target = <<<EOS
+        $target          = <<<EOS
     /**
      * Enter description here...
      *
@@ -238,11 +240,11 @@ EOS;
      */
     public function testDefaultValueGenerationDoesNotIncludeTrailingSemicolon()
     {
-        $method = new MethodGenerator('setOptions');
+        $method  = new MethodGenerator('setOptions');
         $default = new ValueGenerator();
         $default->setValue([]);
 
-        $param   = new ParameterGenerator('options', 'array');
+        $param = new ParameterGenerator('options', 'array');
         $param->setDefaultValue($default);
 
         $method->setParameter($param);
@@ -279,9 +281,9 @@ EOS;
     public function testCreateInterfaceMethodFromArray()
     {
         $methodGenerator = MethodGenerator::fromArray([
-            'name'       => 'execute',
-            'interface'  => true,
-            'docblock'   => [
+            'name'      => 'execute',
+            'interface' => true,
+            'docblock'  => [
                 'shortdescription' => 'Short Description',
             ],
         ]);
@@ -341,9 +343,7 @@ PHP;
 
     /**
      * @group zendframework/zend-code#29
-     *
      * @dataProvider returnTypeHintClasses
-     *
      * @param string $className
      * @param string $methodName
      * @param string $expectedReturnSignature
@@ -355,6 +355,10 @@ PHP;
         self::assertStringMatchesFormat('%A) : ' . $expectedReturnSignature . '%w{%A', $methodGenerator->generate());
     }
 
+    /**
+     * @return string[][]
+     * @psalm-return list<array{class-string, non-empty-string, non-empty-string}>
+     */
     public function returnTypeHintClasses()
     {
         $parameters = [
@@ -392,13 +396,13 @@ PHP;
             [Php80Types::class, 'staticType', 'static'],
         ];
 
-        return array_filter(
+        return array_values(array_filter(
             $parameters,
             function (array $parameter) {
                 return PHP_VERSION_ID >= 80000
                     || $parameter[0] !== Php80Types::class;
             }
-        );
+        ));
     }
 
     /**
@@ -432,9 +436,7 @@ PHP;
     /**
      * @requires PHP >= 8.0
      * @group laminas/laminas-code#53
-     *
      * @dataProvider php80Methods
-     *
      * @psalm-param class-string $className
      * @psalm-param non-empty-string $method
      * @psalm-param non-empty-string $expectedGeneratedSignature
@@ -445,7 +447,7 @@ PHP;
         string $expectedType,
         string $expectedGeneratedSignature
     ): void {
-        $generator = MethodGenerator::fromReflection(new MethodReflection($className, $method));
+        $generator  = MethodGenerator::fromReflection(new MethodReflection($className, $method));
         $returnType = $generator->getReturnType();
 
         self::assertNotNull($returnType);
@@ -464,7 +466,12 @@ PHP;
             [Php80Types::class, 'unionNullableType', 'bool', '?bool'],
             [Php80Types::class, 'unionReverseNullableType', 'bool', '?bool'],
             [Php80Types::class, 'unionNullableTypeWithDefaultValue', 'bool|string|null', 'bool|string|null'],
-            [Php80Types::class, 'unionType', Php80Types::class . '|' . stdClass::class, '\\' . Php80Types::class . '|\\' . stdClass::class],
+            [
+                Php80Types::class,
+                'unionType',
+                Php80Types::class . '|' . stdClass::class,
+                '\\' . Php80Types::class . '|\\' . stdClass::class,
+            ],
             [Php80Types::class, 'staticType', 'static', 'static'],
             [Php80Types::class, 'selfAndBoolType', Php80Types::class . '|bool', '\\' . Php80Types::class . '|bool'],
         ];

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -17,8 +17,9 @@ use Laminas\Code\Generator\PropertyValueGenerator;
 use Laminas\Code\Generator\ValueGenerator;
 use Laminas\Code\Reflection\ClassReflection;
 use PHPUnit\Framework\TestCase;
-
 use ReflectionProperty;
+use stdClass;
+
 use function array_shift;
 use function str_replace;
 
@@ -28,7 +29,7 @@ use function str_replace;
  */
 class PropertyGeneratorTest extends TestCase
 {
-    public function testPropertyConstructor() : void
+    public function testPropertyConstructor(): void
     {
         $codeGenProperty = new PropertyGenerator();
         self::assertInstanceOf(PropertyGenerator::class, $codeGenProperty);
@@ -37,7 +38,7 @@ class PropertyGeneratorTest extends TestCase
     /**
      * @return bool[][]|string[][]|int[][]|null[][]
      */
-    public function dataSetTypeSetValueGenerate() : array
+    public function dataSetTypeSetValueGenerate(): array
     {
         return [
             ['string', 'foo', "'foo';"],
@@ -56,12 +57,9 @@ class PropertyGeneratorTest extends TestCase
 
     /**
      * @dataProvider dataSetTypeSetValueGenerate
-     *
-     * @param string $type
      * @param mixed $value
-     * @param string $code
      */
-    public function testSetTypeSetValueGenerate(string $type, $value, string $code) : void
+    public function testSetTypeSetValueGenerate(string $type, $value, string $code): void
     {
         $defaultValue = new PropertyValueGenerator();
         $defaultValue->setType($type);
@@ -73,12 +71,9 @@ class PropertyGeneratorTest extends TestCase
 
     /**
      * @dataProvider dataSetTypeSetValueGenerate
-     *
-     * @param string $type
      * @param mixed $value
-     * @param string $code
      */
-    public function testSetBogusTypeSetValueGenerateUseAutoDetection(string $type, $value, string $code) : void
+    public function testSetBogusTypeSetValueGenerateUseAutoDetection(string $type, $value, string $code): void
     {
         if ('constant' === $type) {
             self::markTestSkipped('constant can only be detected explicitly');
@@ -91,20 +86,20 @@ class PropertyGeneratorTest extends TestCase
         self::assertEquals($code, $defaultValue->generate());
     }
 
-    public function testPropertyReturnsSimpleValue() : void
+    public function testPropertyReturnsSimpleValue(): void
     {
         $codeGenProperty = new PropertyGenerator('someVal', 'some string value');
         self::assertEquals('    public $someVal = \'some string value\';', $codeGenProperty->generate());
     }
 
-    public function testPropertyMultilineValue() : void
+    public function testPropertyMultilineValue(): void
     {
         $targetValue = [
             5,
-            'one' => 1,
-            'two' => '2',
-            'null' => null,
-            'true' => true,
+            'one'   => 1,
+            'two'   => '2',
+            'null'  => null,
+            'true'  => true,
             "bar's" => "bar's",
         ];
 
@@ -127,7 +122,7 @@ EOS;
         self::assertEquals($expectedSource, $targetSource);
     }
 
-    public function visibility() : Generator
+    public function visibility(): Generator
     {
         yield 'public' => [PropertyGenerator::FLAG_PUBLIC, 'public'];
         yield 'protected' => [PropertyGenerator::FLAG_PROTECTED, 'protected'];
@@ -137,13 +132,13 @@ EOS;
     /**
      * @dataProvider visibility
      */
-    public function testPropertyCanProduceConstatWithVisibility(int $flag, string $visibility) : void
+    public function testPropertyCanProduceConstatWithVisibility(int $flag, string $visibility): void
     {
         $codeGenProperty = new PropertyGenerator('FOO', 'bar', [PropertyGenerator::FLAG_CONSTANT, $flag]);
         self::assertSame('    ' . $visibility . ' const FOO = \'bar\';', $codeGenProperty->generate());
     }
 
-    public function testPropertyCanProduceContstantModifier() : void
+    public function testPropertyCanProduceContstantModifier(): void
     {
         $codeGenProperty = new PropertyGenerator('someVal', 'some string value', PropertyGenerator::FLAG_CONSTANT);
         self::assertEquals('    public const someVal = \'some string value\';', $codeGenProperty->generate());
@@ -152,14 +147,14 @@ EOS;
     /**
      * @group PR-704
      */
-    public function testPropertyCanProduceContstantModifierWithSetter() : void
+    public function testPropertyCanProduceContstantModifierWithSetter(): void
     {
         $codeGenProperty = new PropertyGenerator('someVal', 'some string value');
         $codeGenProperty->setConst(true);
         self::assertEquals('    public const someVal = \'some string value\';', $codeGenProperty->generate());
     }
 
-    public function testPropertyCanProduceStaticModifier() : void
+    public function testPropertyCanProduceStaticModifier(): void
     {
         $codeGenProperty = new PropertyGenerator('someVal', 'some string value', PropertyGenerator::FLAG_STATIC);
         self::assertEquals('    public static $someVal = \'some string value\';', $codeGenProperty->generate());
@@ -168,7 +163,7 @@ EOS;
     /**
      * @group Laminas-6444
      */
-    public function testPropertyWillLoadFromReflection() : void
+    public function testPropertyWillLoadFromReflection(): void
     {
         $reflectionClass = new ClassReflection(TestAsset\TestClassWithManyProperties::class);
 
@@ -195,7 +190,7 @@ EOS;
     /**
      * @group Laminas-6444
      */
-    public function testPropertyWillEmitStaticModifier() : void
+    public function testPropertyWillEmitStaticModifier(): void
     {
         $codeGenProperty = new PropertyGenerator(
             'someVal',
@@ -208,7 +203,7 @@ EOS;
     /**
      * @group Laminas-7205
      */
-    public function testPropertyCanHaveDocBlock() : void
+    public function testPropertyCanHaveDocBlock(): void
     {
         $codeGenProperty = new PropertyGenerator(
             'someVal',
@@ -227,9 +222,9 @@ EOS;
         self::assertEquals($expected, $codeGenProperty->generate());
     }
 
-    public function testOtherTypesThrowExceptionOnGenerate() : void
+    public function testOtherTypesThrowExceptionOnGenerate(): void
     {
-        $codeGenProperty = new PropertyGenerator('someVal', new \stdClass());
+        $codeGenProperty = new PropertyGenerator('someVal', new stdClass());
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Type "stdClass" is unknown or cannot be used as property default value');
@@ -237,7 +232,7 @@ EOS;
         $codeGenProperty->generate();
     }
 
-    public function testCreateFromArray() : void
+    public function testCreateFromArray(): void
     {
         $propertyGenerator = PropertyGenerator::fromArray([
             'name'             => 'SampleProperty',
@@ -273,7 +268,7 @@ EOS;
     /**
      * @group 3491
      */
-    public function testPropertyDocBlockWillLoadFromReflection() : void
+    public function testPropertyDocBlockWillLoadFromReflection(): void
     {
         $reflectionClass = new ClassReflection(TestAsset\TestClassWithManyProperties::class);
 
@@ -284,7 +279,7 @@ EOS;
 
         $docBlock = $cgProp->getDocBlock();
         self::assertInstanceOf(DocBlockGenerator::class, $docBlock);
-        $tags     = $docBlock->getTags();
+        $tags = $docBlock->getTags();
         self::assertIsArray($tags);
         self::assertCount(1, $tags);
         $tag = array_shift($tags);
@@ -294,11 +289,9 @@ EOS;
 
     /**
      * @dataProvider dataSetTypeSetValueGenerate
-     *
-     * @param string $type
      * @param mixed $value
      */
-    public function testSetDefaultValue(string $type, $value) : void
+    public function testSetDefaultValue(string $type, $value): void
     {
         $property = new PropertyGenerator();
         $property->setDefaultValue($value, $type);
@@ -315,13 +308,13 @@ EOS;
         self::assertEquals('    public $foo;', $property->generate());
     }
 
-    public function testFromReflectionOmitsDefaultValueIfItIsNull() : void
+    public function testFromReflectionOmitsDefaultValueIfItIsNull(): void
     {
-        $reflectionClass = new ClassReflection(TestAsset\TestClassWithManyProperties::class);
+        $reflectionClass    = new ClassReflection(TestAsset\TestClassWithManyProperties::class);
         $propertyReflection = $reflectionClass->getProperty('fooStaticProperty');
 
         $generator = PropertyGenerator::fromReflection($propertyReflection);
-        $code = $generator->generate();
+        $code      = $generator->generate();
 
         $this->assertEquals('    public static $fooStaticProperty;', $code);
     }

--- a/test/Generator/TraitGeneratorTest.php
+++ b/test/Generator/TraitGeneratorTest.php
@@ -25,7 +25,7 @@ use function current;
  */
 class TraitGeneratorTest extends TestCase
 {
-    protected function setUp() : void
+    protected function setUp(): void
     {
     }
 
@@ -191,12 +191,12 @@ class TraitGeneratorTest extends TestCase
     public function testToString()
     {
         $classGenerator = TraitGenerator::fromArray([
-            'name' => 'SampleClass',
+            'name'       => 'SampleClass',
             'properties' => [
                 'foo',
                 ['name' => 'bar'],
             ],
-            'methods' => [
+            'methods'    => [
                 ['name' => 'baz'],
             ],
         ]);
@@ -258,7 +258,7 @@ EOS;
     {
         require_once __DIR__ . '/../TestAsset/NonNamespaceClass.php';
 
-        $reflClass = new ClassReflection('LaminasTest_Code_NsTest_BarClass');
+        $reflClass      = new ClassReflection('LaminasTest_Code_NsTest_BarClass');
         $classGenerator = TraitGenerator::fromReflection($reflClass);
         self::assertCount(1, $classGenerator->getMethods());
     }
@@ -306,7 +306,7 @@ CODE;
      */
     public function testCodeGenerationShouldTakeIntoAccountNamespacesFromReflection()
     {
-        $reflClass = new ClassReflection(TestAsset\ClassWithNamespace::class);
+        $reflClass      = new ClassReflection(TestAsset\ClassWithNamespace::class);
         $classGenerator = TraitGenerator::fromReflection($reflClass);
         self::assertEquals('LaminasTest\Code\Generator\TestAsset', $classGenerator->getNamespaceName());
         self::assertEquals('ClassWithNamespace', $classGenerator->getName());
@@ -404,7 +404,7 @@ CODE;
     public function testCreateFromArrayWithDocBlockFromArray()
     {
         $classGenerator = TraitGenerator::fromArray([
-            'name' => 'SampleClass',
+            'name'     => 'SampleClass',
             'docblock' => [
                 'shortdescription' => 'foo',
             ],
@@ -417,7 +417,7 @@ CODE;
     public function testCreateFromArrayWithDocBlockInstance()
     {
         $classGenerator = TraitGenerator::fromArray([
-            'name' => 'SampleClass',
+            'name'     => 'SampleClass',
             'docblock' => new DocBlockGenerator('foo'),
         ]);
 
@@ -427,9 +427,9 @@ CODE;
 
     public function testExtendedClassProperies()
     {
-        $reflClass = new ClassReflection(TestAsset\ExtendedClassWithProperties::class);
+        $reflClass      = new ClassReflection(TestAsset\ExtendedClassWithProperties::class);
         $classGenerator = TraitGenerator::fromReflection($reflClass);
-        $code = $classGenerator->generate();
+        $code           = $classGenerator->generate();
         self::assertStringContainsString('publicExtendedClassProperty', $code);
         self::assertStringContainsString('protectedExtendedClassProperty', $code);
         self::assertStringContainsString('privateExtendedClassProperty', $code);

--- a/test/Generator/TypeGeneratorTest.php
+++ b/test/Generator/TypeGeneratorTest.php
@@ -18,11 +18,11 @@ use function array_filter;
 use function array_map;
 use function class_implements;
 use function ltrim;
+use function str_replace;
 use function strpos;
 
 /**
  * @group zendframework/zend-code#29
- *
  * @covers \Laminas\Code\Generator\TypeGenerator
  * @covers \Laminas\Code\Generator\TypeGenerator\AtomicType
  */
@@ -35,7 +35,6 @@ class TypeGeneratorTest extends TestCase
 
     /**
      * @dataProvider validType
-     *
      * @param string $typeString
      * @param string $expectedReturnType
      */
@@ -48,7 +47,6 @@ class TypeGeneratorTest extends TestCase
 
     /**
      * @dataProvider validType
-     *
      * @param string $typeString
      * @param string $expectedReturnType
      */
@@ -64,7 +62,6 @@ class TypeGeneratorTest extends TestCase
 
     /**
      * @dataProvider invalidType
-     *
      * @param string $typeString
      */
     public function testRejectsInvalidTypeString($typeString)

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -20,24 +20,24 @@ use Laminas\Code\Generator\ValueGenerator;
 use Laminas\Stdlib\ArrayObject as StdlibArrayObject;
 use PHPUnit\Framework\TestCase;
 
+use function fopen;
 use function str_replace;
 
 /**
  * @group Laminas_Code_Generator
  * @group Laminas_Code_Generator_Php
- *
  * @covers \Laminas\Code\Generator\ValueGenerator
  */
 class ValueGeneratorTest extends TestCase
 {
-    public function testDefaultInstance()
+    public function testDefaultInstance(): void
     {
         $valueGenerator = new ValueGenerator();
 
         self::assertInstanceOf(SplArrayObject::class, $valueGenerator->getConstants());
     }
 
-    public function testInvalidConstantsType()
+    public function testInvalidConstantsType(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('$constants must be an instance of ArrayObject or Laminas\Stdlib\ArrayObject');
@@ -48,10 +48,9 @@ class ValueGeneratorTest extends TestCase
 
     /**
      * @dataProvider constantsType
-     *
      * @param SplArrayObject|StdlibArrayObject $constants
      */
-    public function testAllowedPossibleConstantsType($constants)
+    public function testAllowedPossibleConstantsType($constants): void
     {
         $valueGenerator = new ValueGenerator(
             null,
@@ -63,23 +62,24 @@ class ValueGeneratorTest extends TestCase
         self::assertSame($constants, $valueGenerator->getConstants());
     }
 
-    public function constantsType()
+    /**
+     * @return object[][]
+     * @psalm-return array<class-string, array{SplArrayObject|StdlibArrayObject}>
+     */
+    public function constantsType(): array
     {
         return [
-            SplArrayObject::class => [new SplArrayObject()],
+            SplArrayObject::class    => [new SplArrayObject()],
             StdlibArrayObject::class => [new StdlibArrayObject()],
         ];
     }
 
     /**
      * @group #94
-     *
      * @dataProvider validConstantTypes
-     *
-     * @param PropertyValueGenerator $generator
      * @param string $expectedOutput
      */
-    public function testValidConstantTypes(PropertyValueGenerator $generator, $expectedOutput)
+    public function testValidConstantTypes(PropertyValueGenerator $generator, $expectedOutput): void
     {
         $propertyGenerator = new PropertyGenerator('FOO', $generator);
         $propertyGenerator->setConst(true);
@@ -88,8 +88,9 @@ class ValueGeneratorTest extends TestCase
 
     /**
      * @return array
+     * @psalm-return non-empty-list<array{PropertyValueGenerator, non-empty-string}>
      */
-    public function validConstantTypes()
+    public function validConstantTypes(): array
     {
         return [
             [
@@ -191,8 +192,8 @@ EOS;
     {
         $value = [
             5,
-            'one' => 1,
-            'two' => '2',
+            'one'       => 1,
+            'two'       => '2',
             'constant1' => "__DIR__ . '/anydir1/anydir2'",
             [
                 'baz' => true,
@@ -263,7 +264,8 @@ EOS;
                             '5bcf08a0a6449' => '5bcf08a0a6485',
                         ],
                     ],
-                ], '5bcf08a0a64c8' => '5bcf08a0a6540',
+                ],
+                '5bcf08a0a64c8' => '5bcf08a0a6540',
                 '5bcf08a0a657f' => '5bcf08a0a65bf',
             ],
         ];
@@ -339,7 +341,6 @@ EOS;
 
     /**
      * @dataProvider unsortedKeysArray
-     *
      * @param string $type
      * @param array $value
      * @param string $expected
@@ -395,7 +396,6 @@ EOS;
 
     /**
      * @dataProvider simpleArray
-     *
      * @param string $type
      * @param array $value
      * @param string $expected
@@ -427,7 +427,6 @@ EOS;
 
     /**
      * @dataProvider complexArray
-     *
      * @param string $type
      * @param array $value
      * @param string $expected
@@ -449,7 +448,7 @@ EOS;
         string $type,
         array $value,
         string $expected
-    ) : void {
+    ): void {
         $valueGenerator = new ValueGenerator();
         $valueGenerator->setType($type);
         $valueGenerator->setValue($value);
@@ -460,9 +459,7 @@ EOS;
 
     /**
      * @group 6023
-     *
      * @dataProvider getEscapedParameters
-     *
      * @param string $input
      * @param string $expectedEscapedValue
      */
@@ -485,7 +482,7 @@ EOS;
         ];
     }
 
-    public function invalidValue() : Generator
+    public function invalidValue(): Generator
     {
         yield 'object' => [new DateTime(), DateTime::class];
         yield 'resource' => [fopen('php://input', 'r'), 'resource'];
@@ -493,15 +490,14 @@ EOS;
 
     /**
      * @dataProvider invalidValue
-     *
      * @param mixed $value
      */
-    public function testExceptionInvalidValue($value, string $type) : void
+    public function testExceptionInvalidValue($value, string $type): void
     {
         $valueGenerator = new ValueGenerator($value);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Type "'.$type.'" is unknown or cannot be used');
+        $this->expectExceptionMessage('Type "' . $type . '" is unknown or cannot be used');
         $valueGenerator->generate();
     }
 }

--- a/test/Generic/Prototype/PrototypeClassFactoryTest.php
+++ b/test/Generic/Prototype/PrototypeClassFactoryTest.php
@@ -19,17 +19,15 @@ use PHPUnit\Framework\TestCase;
  */
 class PrototypeClassFactoryTest extends TestCase
 {
-    /**
-     * @var PrototypeClassFactory
-     */
+    /** @var PrototypeClassFactory */
     protected $prototypeFactory;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->prototypeFactory = new PrototypeClassFactory();
     }
 
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
         $this->prototypeFactory = null;
     }

--- a/test/Reflection/ClassReflectionTest.php
+++ b/test/Reflection/ClassReflectionTest.php
@@ -11,7 +11,6 @@ namespace LaminasTest\Code\Reflection;
 use Laminas\Code\Reflection\ClassReflection;
 use Laminas\Code\Reflection\MethodReflection;
 use Laminas\Code\Reflection\PropertyReflection;
-use Laminas\Code\Scanner\FileScanner;
 use PHPUnit\Framework\TestCase;
 
 use function array_shift;
@@ -76,7 +75,7 @@ class ClassReflectionTest extends TestCase
     public function testGetContentsReturnsContents()
     {
         $reflectionClass = new ClassReflection(TestAsset\TestSampleClass2::class);
-        $target = <<<EOS
+        $target          = <<<EOS
 {
     protected \$_prop1 = null;
 
@@ -102,14 +101,14 @@ class ClassReflectionTest extends TestCase
 
 }
 EOS;
-        $contents = $reflectionClass->getContents();
+        $contents        = $reflectionClass->getContents();
         self::assertEquals(trim($target), trim($contents));
     }
 
     public function testGetContentsReturnsContentsWithImplementsOnSeparateLine()
     {
         $reflectionClass = new ClassReflection(TestAsset\TestSampleClass9::class);
-        $target = <<<EOS
+        $target          = <<<EOS
 {
     protected \$_prop1 = null;
 
@@ -135,7 +134,7 @@ EOS;
 
 }
 EOS;
-        $contents = $reflectionClass->getContents();
+        $contents        = $reflectionClass->getContents();
         self::assertEquals(trim($target), trim($contents));
     }
 
@@ -170,13 +169,13 @@ EOS;
         // error so I test just normal behaviour.
 
         $reflectionClass = new ClassReflection(TestAsset\TestTraitClass4::class);
-        $traitsArray = $reflectionClass->getTraits();
+        $traitsArray     = $reflectionClass->getTraits();
         self::assertIsArray($traitsArray);
         self::assertCount(1, $traitsArray);
         self::assertInstanceOf(ClassReflection::class, $traitsArray[0]);
 
         $reflectionClass = new ClassReflection(TestAsset\TestSampleClass::class);
-        $traitsArray = $reflectionClass->getTraits();
+        $traitsArray     = $reflectionClass->getTraits();
         self::assertIsArray($traitsArray);
         self::assertCount(0, $traitsArray);
     }

--- a/test/Reflection/DocBlock/Tag/AuthorTagTest.php
+++ b/test/Reflection/DocBlock/Tag/AuthorTagTest.php
@@ -17,12 +17,10 @@ use PHPUnit\Framework\TestCase;
  */
 class AuthorTagTest extends TestCase
 {
-    /**
-     * @var AuthorTag
-     */
+    /** @var AuthorTag */
     protected $tag;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->tag = new AuthorTag();
     }

--- a/test/Reflection/DocBlock/Tag/LicenseTagTest.php
+++ b/test/Reflection/DocBlock/Tag/LicenseTagTest.php
@@ -17,12 +17,10 @@ use PHPUnit\Framework\TestCase;
  */
 class LicenseTagTest extends TestCase
 {
-    /**
-     * @var LicenseTag
-     */
+    /** @var LicenseTag */
     protected $tag;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->tag = new LicenseTag();
     }

--- a/test/Reflection/DocBlock/Tag/VarTagTest.php
+++ b/test/Reflection/DocBlock/Tag/VarTagTest.php
@@ -36,55 +36,55 @@ class VarTagTest extends TestCase
     public function varTagProvider(): array
     {
         return [
-            'only type' => [
+            'only type'                            => [
                 'string',
                 ['string'],
                 null,
                 null,
             ],
-            'only multiple types' => [
+            'only multiple types'                  => [
                 'string|int',
                 ['string', 'int'],
                 null,
                 null,
             ],
-            'type and name' => [
+            'type and name'                        => [
                 'string $test',
                 ['string'],
                 '$test',
                 null,
             ],
-            'multiple types and name' => [
+            'multiple types and name'              => [
                 'string|int $test',
                 ['string', 'int'],
                 '$test',
                 null,
             ],
-            'only name' => [
+            'only name'                            => [
                 '$test',
                 [],
                 '$test',
                 null,
             ],
-            'name and description' => [
+            'name and description'                 => [
                 '$test Foo Bar',
                 [],
                 '$test',
                 'Foo Bar',
             ],
-            'type and description' => [
+            'type and description'                 => [
                 'string Foo bar',
                 ['string'],
                 null,
                 'Foo bar',
             ],
-            'multiple types and description' => [
+            'multiple types and description'       => [
                 'string|int Foo bar',
                 ['string', 'int'],
                 null,
                 'Foo bar',
             ],
-            'type, name and description' => [
+            'type, name and description'           => [
                 'string $test Foo bar',
                 ['string'],
                 '$test',
@@ -96,7 +96,6 @@ class VarTagTest extends TestCase
                 '$test',
                 'Foo bar',
             ],
-
         ];
     }
 }

--- a/test/Reflection/DocBlockReflectionTest.php
+++ b/test/Reflection/DocBlockReflectionTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @copyright  Copyright (c) 2005-2016 Laminas (https://www.zend.com)
  * @license    https://getlaminas.org/license/new-bsd     New BSD License
+ *
  * @group      Laminas_Reflection
  * @group      Laminas_Reflection_DocBlock
  */
@@ -38,9 +39,8 @@ class DocBlockReflectionTest extends TestCase
     public function testDocBlockLongDescription()
     {
         $classReflection = new ClassReflection(TestAsset\TestSampleClass5::class);
-        $expectedOutput = 'This is a long description for the docblock of this class, it should be longer '
+        $expectedOutput  = 'This is a long description for the docblock of this class, it should be longer '
             . 'than 3 lines. It indeed is longer than 3 lines now.';
-
 
         self::assertEquals($expectedOutput, $classReflection->getDocBlock()->getLongDescription());
     }

--- a/test/Reflection/FunctionReflectionTest.php
+++ b/test/Reflection/FunctionReflectionTest.php
@@ -26,7 +26,7 @@ class FunctionReflectionTest extends TestCase
 {
     public function testParemeterReturn()
     {
-        $function = new FunctionReflection('array_splice');
+        $function   = new FunctionReflection('array_splice');
         $parameters = $function->getParameters();
         self::assertCount(4, $parameters);
         self::assertInstanceOf(ParameterReflection::class, array_shift($parameters));
@@ -43,11 +43,11 @@ class FunctionReflectionTest extends TestCase
     {
         require_once __DIR__ . '/TestAsset/functions.php';
 
-        $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function2');
+        $function  = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function2');
         $prototype = [
             'namespace' => 'LaminasTest\Code\Reflection\TestAsset',
-            'name' => 'function2',
-            'return' => 'string',
+            'name'      => 'function2',
+            'return'    => 'string',
             'arguments' => [
                 'one' => [
                     'type'     => 'string',
@@ -82,43 +82,43 @@ class FunctionReflectionTest extends TestCase
         require_once __DIR__ . '/TestAsset/functions.php';
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function1');
-        $body = $function->getBody();
+        $body     = $function->getBody();
         self::assertEquals("return 'function1';", trim($body));
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function4');
-        $body = $function->getBody();
+        $body     = $function->getBody();
         self::assertEquals("return 'function4';", trim($body));
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function5');
-        $body = $function->getBody();
+        $body     = $function->getBody();
         self::assertEquals("return 'function5';", trim($body));
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function6');
-        $body = $function->getBody();
+        $body     = $function->getBody();
         self::assertEquals("\$closure = function() { return 'bar'; };\n    return 'function6';", trim($body));
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function7');
-        $body = $function->getBody();
+        $body     = $function->getBody();
         self::assertEquals("return 'function7';", trim($body));
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function8');
-        $body = $function->getBody();
+        $body     = $function->getBody();
         self::assertEquals("return 'function8';", trim($body));
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function9');
-        $body = $function->getBody();
+        $body     = $function->getBody();
         self::assertEquals("return 'function9';", trim($body));
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function10');
-        $body = $function->getBody();
+        $body     = $function->getBody();
         self::assertEquals("\$closure = function() { return 'function10'; }; return \$closure();", trim($body));
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function11');
-        $body = $function->getBody();
+        $body     = $function->getBody();
         self::assertEquals("return 'function11';", trim($body));
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function12');
-        $body = $function->getBody() ?: '';
+        $body     = $function->getBody() ?: '';
         self::assertEquals('', trim($body));
     }
 
@@ -127,46 +127,46 @@ class FunctionReflectionTest extends TestCase
         require __DIR__ . '/TestAsset/closures.php';
 
         $function = new FunctionReflection($function1);
-        $body = $function->getBody();
+        $body     = $function->getBody();
         self::assertEquals("return 'function1';", trim($body));
 
         $function = new FunctionReflection($function2);
-        $body = $function->getBody();
+        $body     = $function->getBody();
         self::assertEquals("return 'function2';", trim($body));
 
         $function = new FunctionReflection($function3);
-        $body = $function->getBody();
+        $body     = $function->getBody();
         self::assertEquals("return 'function3';", trim($body));
 
         $function = new FunctionReflection($function4);
-        $body = $function->getBody();
+        $body     = $function->getBody();
         self::assertEquals("\$closure = function() { return 'bar'; };\n    return 'function4';", trim($body));
 
         $function5 = $list1['closure'];
-        $function = new FunctionReflection($function5);
-        $body = $function->getBody();
+        $function  = new FunctionReflection($function5);
+        $body      = $function->getBody();
         self::assertEquals("return 'function5';", trim($body));
 
         $function6 = $list2[0];
-        $function = new FunctionReflection($function6);
-        $body = $function->getBody();
+        $function  = new FunctionReflection($function6);
+        $body      = $function->getBody();
         self::assertEquals("return 'function6';", trim($body));
 
         $function7 = $list3[0];
-        $function = new FunctionReflection($function7);
-        $body = $function->getBody();
+        $function  = new FunctionReflection($function7);
+        $body      = $function->getBody();
         self::assertEquals("return \$c = function() { return 'function7'; }; return \$c();", trim($body));
 
         $function = new FunctionReflection($function8);
-        $body = $function->getBody();
+        $body     = $function->getBody();
         self::assertEquals("return 'function 8';", trim($body));
 
         $function = new FunctionReflection($function9);
-        $body = $function->getBody() ?: '';
+        $body     = $function->getBody() ?: '';
         self::assertEquals('', trim($body));
 
         $function = new FunctionReflection($function10);
-        $body = $function->getBody();
+        $body     = $function->getBody();
         self::assertEquals("return 'function10';", trim($body));
     }
 
@@ -182,49 +182,49 @@ class FunctionReflectionTest extends TestCase
         require_once __DIR__ . '/TestAsset/functions.php';
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function1');
-        $content = $function->getContents(false);
+        $content  = $function->getContents(false);
         self::assertEquals("function function1()\n{\n    return 'function1';\n}", trim($content));
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function4');
-        $content = $function->getContents(false);
+        $content  = $function->getContents(false);
         self::assertEquals("function function4(\$arg) {\n    return 'function4';\n}", trim($content));
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function5');
-        $content = $function->getContents(false);
+        $content  = $function->getContents(false);
         self::assertEquals("function function5() { return 'function5'; }", trim($content));
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function6');
-        $content = $function->getContents(false);
+        $content  = $function->getContents(false);
         self::assertEquals(
             "function function6()\n{\n    \$closure = function() { return 'bar'; };\n    return 'function6';\n}",
             trim($content)
         );
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function7');
-        $content = $function->getContents(false);
+        $content  = $function->getContents(false);
         self::assertEquals("function function7() { return 'function7'; }", trim($content));
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function8');
-        $content = $function->getContents(false);
+        $content  = $function->getContents(false);
         self::assertEquals("function function8() { return 'function8'; }", trim($content));
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function9');
-        $content = $function->getContents(false);
+        $content  = $function->getContents(false);
         self::assertEquals("function function9() { return 'function9'; }", trim($content));
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function10');
-        $content = $function->getContents(false);
+        $content  = $function->getContents(false);
         self::assertEquals(
             "function function10() { \$closure = function() { return 'function10'; }; return \$closure(); }",
             trim($content)
         );
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function11');
-        $content = $function->getContents(false);
+        $content  = $function->getContents(false);
         self::assertEquals("function function11() { return 'function11'; }", trim($content));
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function12');
-        $content = $function->getContents(false);
+        $content  = $function->getContents(false);
         self::assertEquals('function function12() {}', trim($content));
     }
 
@@ -236,15 +236,15 @@ class FunctionReflectionTest extends TestCase
         require __DIR__ . '/TestAsset/closures.php';
 
         $function = new FunctionReflection($function2);
-        $content = $function->getContents(false);
+        $content  = $function->getContents(false);
         self::assertEquals("function() { return 'function2'; }", trim($content));
 
         $function = new FunctionReflection($function9);
-        $content = $function->getContents(false);
+        $content  = $function->getContents(false);
         self::assertEquals('function() {}', trim($content));
 
         $function = new FunctionReflection($function10);
-        $content = $function->getContents(false);
+        $content  = $function->getContents(false);
         self::assertEquals("function() { return 'function10'; }", trim($content));
     }
 
@@ -253,7 +253,7 @@ class FunctionReflectionTest extends TestCase
         require_once __DIR__ . '/TestAsset/functions.php';
 
         $function = new FunctionReflection('LaminasTest\Code\Reflection\TestAsset\function3');
-        $content = $function->getContents();
+        $content  = $function->getContents();
         self::assertEquals(
             "/**\n * Enter description here...\n *\n * @param string \$one\n * @param int \$two"
             . "\n * @return true\n */\nfunction function3(\$one, \$two = 2)\n{\n    return true;\n}",
@@ -266,7 +266,7 @@ class FunctionReflectionTest extends TestCase
         require __DIR__ . '/TestAsset/closures.php';
 
         $function = new FunctionReflection($function9);
-        $content = $function->getContents();
+        $content  = $function->getContents();
         self::assertEquals("/**\n * closure doc block\n */\nfunction() {}", trim($content));
     }
 

--- a/test/Reflection/MethodReflectionTest.php
+++ b/test/Reflection/MethodReflectionTest.php
@@ -11,7 +11,6 @@ namespace LaminasTest\Code\Reflection;
 use Laminas\Code\Reflection\ClassReflection;
 use Laminas\Code\Reflection\MethodReflection;
 use Laminas\Code\Reflection\ParameterReflection;
-use Laminas\Code\Scanner\CachingFileScanner;
 use PHPUnit\Framework\TestCase;
 
 use function array_shift;
@@ -32,7 +31,7 @@ class MethodReflectionTest extends TestCase
 
     public function testParemeterReturn()
     {
-        $method = new MethodReflection(TestAsset\TestSampleClass2::class, 'getProp2');
+        $method     = new MethodReflection(TestAsset\TestSampleClass2::class, 'getProp2');
         $parameters = $method->getParameters();
         self::assertCount(2, $parameters);
         self::assertInstanceOf(ParameterReflection::class, array_shift($parameters));
@@ -64,42 +63,42 @@ class MethodReflectionTest extends TestCase
         self::assertEquals($body, $reflectionMethod->getBody());
 
         $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'doSomething');
-        $body = $reflectionMethod->getBody();
+        $body             = $reflectionMethod->getBody();
         self::assertEquals(trim($body), "return 'doSomething';");
 
         $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'doSomethingElse');
-        $body = $reflectionMethod->getBody();
+        $body             = $reflectionMethod->getBody();
         self::assertEquals(trim($body), "return 'doSomethingElse';");
 
         $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'doSomethingAgain');
-        $body = $reflectionMethod->getBody();
+        $body             = $reflectionMethod->getBody();
         self::assertEquals(
             trim($body),
             "\$closure = function(\$foo) { return \$foo; };\n\n        return 'doSomethingAgain';"
         );
 
         $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'doStaticSomething');
-        $body = $reflectionMethod->getBody();
+        $body             = $reflectionMethod->getBody();
         self::assertEquals(trim($body), "return 'doStaticSomething';");
 
         $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'inline1');
-        $body = $reflectionMethod->getBody();
+        $body             = $reflectionMethod->getBody();
         self::assertEquals(trim($body), "return 'inline1';");
 
         $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'inline2');
-        $body = $reflectionMethod->getBody();
+        $body             = $reflectionMethod->getBody();
         self::assertEquals(trim($body), "return 'inline2';");
 
         $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'inline3');
-        $body = $reflectionMethod->getBody();
+        $body             = $reflectionMethod->getBody();
         self::assertEquals(trim($body), "return 'inline3';");
 
         $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'emptyFunction');
-        $body = $reflectionMethod->getBody();
+        $body             = $reflectionMethod->getBody();
         self::assertEquals(trim($body), '');
 
         $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'visibility');
-        $body = $reflectionMethod->getBody();
+        $body             = $reflectionMethod->getBody();
         self::assertEquals(trim($body), "return 'visibility';");
     }
 
@@ -114,7 +113,7 @@ class MethodReflectionTest extends TestCase
      */
     public function testMethodContentsReturnWithoutDocBlock()
     {
-        $contents = <<<CONTENTS
+        $contents         = <<<CONTENTS
     public function doSomething()
     {
         return 'doSomething';
@@ -123,7 +122,7 @@ CONTENTS;
         $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'doSomething');
         self::assertEquals($contents, $reflectionMethod->getContents(false));
 
-        $contents = '    public function doSomethingElse($one, $two = 2, $three = \'three\')'
+        $contents         = '    public function doSomethingElse($one, $two = 2, $three = \'three\')'
             . ' { return \'doSomethingElse\'; }';
         $reflectionMethod = new MethodReflection(
             TestAsset\TestSampleClass11::class,
@@ -131,7 +130,7 @@ CONTENTS;
         );
         self::assertEquals($contents, $reflectionMethod->getContents(false));
 
-        $contents = <<<'CONTENTS'
+        $contents         = <<<'CONTENTS'
     public function doSomethingAgain()
     {
         $closure = function($foo) { return $foo; };
@@ -145,19 +144,19 @@ CONTENTS;
         );
         self::assertEquals($contents, $reflectionMethod->getContents(false));
 
-        $contents = '    public function inline1() { return \'inline1\'; }';
+        $contents         = '    public function inline1() { return \'inline1\'; }';
         $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'inline1');
         self::assertEquals($contents, $reflectionMethod->getContents(false));
 
-        $contents = ' public function inline2() { return \'inline2\'; }';
+        $contents         = ' public function inline2() { return \'inline2\'; }';
         $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'inline2');
         self::assertEquals($contents, $reflectionMethod->getContents(false));
 
-        $contents = ' public function inline3() { return \'inline3\'; }';
+        $contents         = ' public function inline3() { return \'inline3\'; }';
         $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'inline3');
         self::assertEquals($contents, $reflectionMethod->getContents(false));
 
-        $contents = <<<'CONTENTS'
+        $contents         = <<<'CONTENTS'
     public function visibility()
     {
         return 'visibility';
@@ -169,7 +168,7 @@ CONTENTS;
 
     public function testFunctionContentsReturnWithDocBlock()
     {
-        $contents = <<<'CONTENTS'
+        $contents         = <<<'CONTENTS'
 /**
      * Doc block doSomething
      * @return string
@@ -202,20 +201,20 @@ CONTENTS;
             TestAsset\TestSampleClass10::class,
             'doSomethingElse'
         );
-        $prototype = [
-            'namespace' => 'LaminasTest\Code\Reflection\TestAsset',
-            'class' => 'TestSampleClass10',
-            'name' => 'doSomethingElse',
+        $prototype        = [
+            'namespace'  => 'LaminasTest\Code\Reflection\TestAsset',
+            'class'      => 'TestSampleClass10',
+            'name'       => 'doSomethingElse',
             'visibility' => 'public',
-            'return' => 'int',
-            'arguments' => [
-                'one' => [
+            'return'     => 'int',
+            'arguments'  => [
+                'one'   => [
                     'type'     => 'int',
                     'required' => true,
                     'by_ref'   => false,
                     'default'  => null,
                 ],
-                'two' => [
+                'two'   => [
                     'type'     => 'int',
                     'required' => false,
                     'by_ref'   => false,
@@ -236,13 +235,13 @@ CONTENTS;
         );
 
         $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass2::class, 'getProp2');
-        $prototype = [
-            'namespace' => 'LaminasTest\Code\Reflection\TestAsset',
-            'class' => 'TestSampleClass2',
-            'name' => 'getProp2',
+        $prototype        = [
+            'namespace'  => 'LaminasTest\Code\Reflection\TestAsset',
+            'class'      => 'TestSampleClass2',
+            'name'       => 'getProp2',
             'visibility' => 'public',
-            'return' => 'mixed',
-            'arguments' => [
+            'return'     => 'mixed',
+            'arguments'  => [
                 'param1' => [
                     'type'     => '',
                     'required' => true,
@@ -264,13 +263,13 @@ CONTENTS;
         );
 
         $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass12::class, 'doSomething');
-        $prototype = [
-            'namespace' => 'LaminasTest\Code\Reflection\TestAsset',
-            'class' => 'TestSampleClass12',
-            'name' => 'doSomething',
+        $prototype        = [
+            'namespace'  => 'LaminasTest\Code\Reflection\TestAsset',
+            'class'      => 'TestSampleClass12',
+            'name'       => 'doSomething',
             'visibility' => 'protected',
-            'return' => 'string',
-            'arguments' => [
+            'return'     => 'string',
+            'arguments'  => [
                 'one' => [
                     'type'     => 'int',
                     'required' => true,

--- a/test/Reflection/ParameterReflectionTest.php
+++ b/test/Reflection/ParameterReflectionTest.php
@@ -8,12 +8,14 @@
 
 namespace LaminasTest\Code\Reflection;
 
+use Closure;
 use Laminas\Code\Reflection;
 use Laminas\Code\Reflection\ClassReflection;
 use LaminasTest\Code\TestAsset\ClassTypeHintedClass;
 use LaminasTest\Code\TestAsset\DocBlockOnlyHintsClass;
 use LaminasTest\Code\TestAsset\InternalHintsClass;
 use PHPUnit\Framework\TestCase;
+use ReflectionType;
 
 /**
  * @group Laminas_Reflection
@@ -50,7 +52,6 @@ class ParameterReflectionTest extends TestCase
 
     /**
      * @dataProvider paramType
-     *
      * @param string $param
      * @param string $type
      */
@@ -72,22 +73,24 @@ class ParameterReflectionTest extends TestCase
         self::assertEquals('callable', $parameter->detectType());
     }
 
-    public function paramType()
+    /**
+     * @return string[][]
+     * @psalm-return non-empty-list<array{non-empty-string, non-empty-string}>
+     */
+    public function paramType(): array
     {
         return [
-            ['one','int'],
-            ['two','int'],
-            ['three','string'],
-            ['array','array'],
-            ['class',TestAsset\TestSampleClass::class],
+            ['one', 'int'],
+            ['two', 'int'],
+            ['three', 'string'],
+            ['array', 'array'],
+            ['class', TestAsset\TestSampleClass::class],
         ];
     }
 
     /**
      * @group zendframework/zend-code#29
-     *
      * @dataProvider reflectionHints
-     *
      * @param string $className
      * @param string $methodName
      * @param string $parameterName
@@ -102,15 +105,13 @@ class ParameterReflectionTest extends TestCase
 
         $type = $reflection->getType();
 
-        self::assertInstanceOf(\ReflectionType::class, $type);
+        self::assertInstanceOf(ReflectionType::class, $type);
         self::assertSame($expectedType, $type->getName());
     }
 
     /**
      * @group zendframework/zend-code#29
-     *
      * @dataProvider reflectionHints
-     *
      * @param string $className
      * @param string $methodName
      * @param string $parameterName
@@ -146,16 +147,14 @@ class ParameterReflectionTest extends TestCase
             [ClassTypeHintedClass::class, 'selfParameter', 'foo', 'self'],
             [ClassTypeHintedClass::class, 'classParameter', 'foo', ClassTypeHintedClass::class],
             [ClassTypeHintedClass::class, 'otherClassParameter', 'foo', InternalHintsClass::class],
-            [ClassTypeHintedClass::class, 'closureParameter', 'foo', \Closure::class],
-            [ClassTypeHintedClass::class, 'importedClosureParameter', 'foo', \Closure::class],
+            [ClassTypeHintedClass::class, 'closureParameter', 'foo', Closure::class],
+            [ClassTypeHintedClass::class, 'importedClosureParameter', 'foo', Closure::class],
         ];
     }
 
     /**
      * @group zendframework/zend-code#29
-     *
      * @dataProvider docBlockHints
-     *
      * @param string $className
      * @param string $methodName
      * @param string $parameterName
@@ -172,9 +171,7 @@ class ParameterReflectionTest extends TestCase
 
     /**
      * @group zendframework/zend-code#29
-     *
      * @dataProvider docBlockHints
-     *
      * @param string $className
      * @param string $methodName
      * @param string $parameterName

--- a/test/Reflection/PropertyReflectionTest.php
+++ b/test/Reflection/PropertyReflectionTest.php
@@ -10,10 +10,7 @@ namespace LaminasTest\Code\Reflection;
 
 use Laminas\Code\Reflection\ClassReflection;
 use Laminas\Code\Reflection\PropertyReflection;
-use Laminas\Code\Scanner\CachingFileScanner;
 use PHPUnit\Framework\TestCase;
-
-use function get_class;
 
 /**
  * @group      Laminas_Reflection

--- a/test/Reflection/ReflectionDocBlockTagTest.php
+++ b/test/Reflection/ReflectionDocBlockTagTest.php
@@ -102,7 +102,7 @@ class ReflectionDocBlockTagTest extends TestCase
     public function testNamespaceInParam()
     {
         $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass7::class);
-        $paramTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('param');
+        $paramTag        = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('param');
 
         self::assertEquals('Laminas\Foo\Bar', $paramTag->getType());
         self::assertEquals('$var', $paramTag->getVariableName());
@@ -170,14 +170,14 @@ class ReflectionDocBlockTagTest extends TestCase
     public function propertyVarDocProvider(): array
     {
         return [
-            'only type' => ['onlyType', ['string'], null, null],
-            'type and description' => [
+            'only type'                  => ['onlyType', ['string'], null, null],
+            'type and description'       => [
                 'typeDescription',
                 ['string'],
                 null,
                 'Foo bar',
             ],
-            'type and name' => ['typeName', ['string'], '$typeName', null],
+            'type and name'              => ['typeName', ['string'], '$typeName', null],
             'type, name and description' => [
                 'typeNameDescription',
                 ['string'],

--- a/test/Scanner/DocBlockScannerTest.php
+++ b/test/Scanner/DocBlockScannerTest.php
@@ -23,13 +23,13 @@ class DocBlockScannerTest extends TestCase
      */
     public function testDocBlockScannerParsesTagsWithNoValuesProperly()
     {
-        $docComment = <<<EOB
+        $docComment   = <<<EOB
 /**
  * @mytag
  */
 EOB;
         $tokenScanner = new DocBlockScanner($docComment);
-        $tags = $tokenScanner->getTags();
+        $tags         = $tokenScanner->getTags();
         self::assertCount(1, $tags);
         self::assertArrayHasKey('name', $tags[0]);
         self::assertEquals('@mytag', $tags[0]['name']);
@@ -39,7 +39,7 @@ EOB;
 
     public function testDocBlockScannerDescriptions()
     {
-        $docComment = <<<EOB
+        $docComment   = <<<EOB
 /**
  * Short Description
  *
@@ -52,7 +52,7 @@ EOB;
         self::assertEquals('Long Description continued in the second line', $tokenScanner->getLongDescription());
 
         // windows-style line separators
-        $docComment = str_replace("\n", "\r\n", $docComment);
+        $docComment   = str_replace("\n", "\r\n", $docComment);
         $tokenScanner = new DocBlockScanner($docComment);
         self::assertEquals('Short Description', $tokenScanner->getShortDescription());
         self::assertEquals('Long Description continued in the second line', $tokenScanner->getLongDescription());


### PR DESCRIPTION
Resolves #62 

|    Q          |   A
|-------------- | ------
| Documentation | yes/no
| Bugfix        | yes/no
| BC Break      | yes/no
| New Feature   | yes/no
| RFC           | yes/no
| QA            | yes/no

### Description

This patch:

 * locks dependencies so that things are stable during builds (mostly for phpcs/psalm, which are too volatile to leave unlocked)
 * applies automatic CS rules and improves types where applicable (although not extensively: that requires a lot of additional work that should **NOT** be done here)

Few false-positive BC breaks were reported, but they are just a result of bringing reality and documentation a bit closer together:


```
[BC] CHANGED: Type documentation for property Laminas\Code\Generator\FileGenerator#$classes changed from array to \Laminas\Code\Generator\ClassGenerator[]
[BC] CHANGED: Type documentation for property Laminas\Code\Reflection\DocBlock\Tag\ThrowsTag#$types changed from array to string[]
[BC] CHANGED: Type documentation for property Laminas\Code\Reflection\DocBlock\Tag\MethodTag#$types changed from array to string[]
[BC] CHANGED: Type documentation for property Laminas\Code\Reflection\DocBlock\Tag\PropertyTag#$types changed from array to string[]
[BC] CHANGED: Type documentation for property Laminas\Code\Reflection\DocBlock\Tag\ParamTag#$types changed from array to string[]
```