### PR TITLE
Consider missing indices in PropertyGenerator

### DIFF
--- a/src/Generator/PropertyGenerator.php
+++ b/src/Generator/PropertyGenerator.php
@@ -35,7 +35,7 @@ class PropertyGenerator extends AbstractMemberGenerator
 
         $allDefaultProperties = $reflectionProperty->getDeclaringClass()->getDefaultProperties();
 
-        $defaultValue = $allDefaultProperties[$reflectionProperty->getName()];
+        $defaultValue = $allDefaultProperties[$reflectionProperty->getName()] ?? null;
         $property->setDefaultValue($defaultValue);
         if ($defaultValue === null) {
             $property->omitDefaultValue = true;

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -16,6 +16,8 @@ use Laminas\Code\Generator\PropertyGenerator;
 use Laminas\Code\Generator\PropertyValueGenerator;
 use Laminas\Code\Generator\ValueGenerator;
 use Laminas\Code\Reflection\ClassReflection;
+use Laminas\Code\Reflection\PropertyReflection;
+use LaminasTest\Code\Generator\TestAsset\ClassWithTypedProperty;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use stdClass;
@@ -323,5 +325,15 @@ EOS;
         $code      = $generator->generate();
 
         $this->assertSame('    public static $fooStaticProperty;', $code);
+    }
+
+    public function testFromReflectionOmitsTypeHintInTypedProperty(): void
+    {
+        $reflectionProperty = new PropertyReflection(ClassWithTypedProperty::class, 'typedProperty');
+
+        $generator = PropertyGenerator::fromReflection($reflectionProperty);
+        $code      = $generator->generate();
+
+        self::assertSame('    private $typedProperty;', $code);
     }
 }

--- a/test/Generator/TestAsset/ClassWithTypedProperty.php
+++ b/test/Generator/TestAsset/ClassWithTypedProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Code\Generator\TestAsset;
+
+final class ClassWithTypedProperty
+{
+    private string $typedProperty;
+
+    public function __construct(string $typedProperty)
+    {
+        $this->typedProperty = $typedProperty;
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fix missing array index `E_NOTICE` error in `PropertyGenerator`.

fixes #76

Edit: The test explicitly checks, that typed properties will be ignored when generating the code. Maybe that feature should be implemented in a future release, and that will cause this test to fail.