### PR TITLE
Fix `DocBlockGenerator` formatting issue when docblock long description is not available

### DIFF
--- a/src/Generator/DocBlockGenerator.php
+++ b/src/Generator/DocBlockGenerator.php
@@ -228,10 +228,10 @@ class DocBlockGenerator extends AbstractGenerator
         }
 
         $output = '';
-        if (null !== ($sd = $this->getShortDescription())) {
+        if ($sd = $this->getShortDescription()) {
             $output .= $sd . self::LINE_FEED . self::LINE_FEED;
         }
-        if (null !== ($ld = $this->getLongDescription())) {
+        if ($ld = $this->getLongDescription()) {
             $output .= $ld . self::LINE_FEED . self::LINE_FEED;
         }
 

--- a/test/Generator/DocBlockGeneratorTest.php
+++ b/test/Generator/DocBlockGeneratorTest.php
@@ -202,4 +202,21 @@ EOS;
         $tags = $this->reflectionDocBlockGenerator->getTags();
         self::assertInstanceOf(ReturnTag::class, $tags[3]);
     }
+
+    public function testGenerateOmitsLongDescriptionWithTags(): void
+    {
+        $generator = new DocBlockGenerator(
+            "foo",
+            null,
+            [new Tag\GenericTag("var", "array")],
+        );
+
+        $expected = '/**' . DocBlockGenerator::LINE_FEED
+            . ' * foo' . DocBlockGenerator::LINE_FEED
+            . ' *' . DocBlockGenerator::LINE_FEED
+            . ' * @var array' . DocBlockGenerator::LINE_FEED
+            . ' */' . DocBlockGenerator::LINE_FEED;
+
+        self::assertSame($expected, $generator->generate());
+    }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fixes #80.

See there for issue description.

In #80 I suggested two possible solutions:

> Do not initialize $longDescription (and probably also $shortDescription) with empty strings, but with null instead.
>
>Alternatively, do not test for !== null when asserting that a long (or short) description is set, but just test for being falsy.

To initialize `$longDescription` with `null`, the type hint of that property would need to be changed from `string` to `?string`, which (since the property is `protected`) might be considered a breaking change.

For that reason, I opted to implement my alternative solution, which effectively results in treating an empty (but non-null) "long description" as equivalent to "not set".

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
