### PR TITLE
Support for PHP 8.1

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -19,6 +19,7 @@ jobs:
         php-version:
           - "7.4"
           - "8.0"
+          - "8.1"
         operating-system:
           - "ubuntu-latest"
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "homepage": "https://laminas.dev",
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^7.4 || ~8.0.0"
+        "php": ">=7.4, <8.2"
     },
     "conflict": {
         "phpspec/prophecy": "<1.9.0"
@@ -19,7 +19,7 @@
         "doctrine/annotations": "^1.10.4",
         "laminas/laminas-coding-standard": "^2.3.0",
         "laminas/laminas-stdlib": "^3.3.0",
-        "phpunit/phpunit": "^9.4.2",
+        "phpunit/phpunit": "^9.5.9",
         "psalm/plugin-phpunit": "^0.14.0",
         "vimeo/psalm": "^4.3.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84d0d82a51f336472dea1684ccd19451",
+    "content-hash": "9f7eb64d978b595fb90e1b7faf8ed85f",
     "packages": [],
     "packages-dev": [
         {
@@ -1098,16 +1098,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.10.3",
+            "version": "v4.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984"
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984",
-                "reference": "dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6608f01670c3cc5079e18c1dab1104e002579143",
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143",
                 "shasum": ""
             },
             "require": {
@@ -1148,9 +1148,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.3"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.12.0"
             },
-            "time": "2020-12-03T17:45:45+00:00"
+            "time": "2021-07-21T10:44:31+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -1207,16 +1207,16 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
@@ -1261,22 +1261,22 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/master"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
             },
-            "time": "2020-06-27T14:33:11+00:00"
+            "time": "2021-07-20T11:28:43+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "3.0.3",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "726c026815142e4f8677b7cb7f2249c9ffb7ecae"
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/726c026815142e4f8677b7cb7f2249c9ffb7ecae",
-                "reference": "726c026815142e4f8677b7cb7f2249c9ffb7ecae",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
                 "shasum": ""
             },
             "require": {
@@ -1312,9 +1312,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.0.3"
+                "source": "https://github.com/phar-io/version/tree/3.1.0"
             },
-            "time": "2020-11-30T09:21:21+00:00"
+            "time": "2021-02-23T14:00:09+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1476,33 +1476,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.1",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d"
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/8ce87516be71aae9b956f81906aaf0338e0d8a2d",
-                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.1",
+                "php": "^7.2 || ~8.0, <8.2",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^6.0",
-                "phpunit/phpunit": "^8.0 || ^9.0 <9.3"
+                "phpspec/phpspec": "^6.0 || ^7.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -1537,9 +1537,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.12.1"
+                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
             },
-            "time": "2020-09-29T09:10:42+00:00"
+            "time": "2021-09-10T09:02:12+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -1592,16 +1592,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.5",
+            "version": "9.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1"
+                "reference": "f6293e1b30a2354e8428e004689671b83871edde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f3e026641cc91909d421802dd3ac7827ebfd97e1",
-                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f6293e1b30a2354e8428e004689671b83871edde",
+                "reference": "f6293e1b30a2354e8428e004689671b83871edde",
                 "shasum": ""
             },
             "require": {
@@ -1657,7 +1657,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.5"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.6"
             },
             "funding": [
                 {
@@ -1665,7 +1665,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:44:49+00:00"
+            "time": "2021-03-28T07:26:59+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1910,16 +1910,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.0",
+            "version": "9.5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "8e16c225d57c3d6808014df6b1dd7598d0a5bbbe"
+                "reference": "ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8e16c225d57c3d6808014df6b1dd7598d0a5bbbe",
-                "reference": "8e16c225d57c3d6808014df6b1dd7598d0a5bbbe",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b",
+                "reference": "ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b",
                 "shasum": ""
             },
             "require": {
@@ -1931,7 +1931,7 @@
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.1",
+                "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
@@ -1949,7 +1949,7 @@
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3",
+                "sebastian/type": "^2.3.4",
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
@@ -1997,7 +1997,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.0"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.9"
             },
             "funding": [
                 {
@@ -2009,7 +2009,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-12-04T05:05:53+00:00"
+            "time": "2021-08-31T06:47:40+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -2680,16 +2680,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.2",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455"
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/a90ccbddffa067b51f574dea6eb25d5680839455",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
                 "shasum": ""
             },
             "require": {
@@ -2732,7 +2732,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
             },
             "funding": [
                 {
@@ -2740,7 +2740,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:55:19+00:00"
+            "time": "2021-06-11T13:31:12+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -3027,20 +3027,21 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-09-28T06:45:17+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "2.3.1",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2"
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
                 "shasum": ""
             },
             "require": {
@@ -3075,7 +3076,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/2.3.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
             },
             "funding": [
                 {
@@ -3083,7 +3084,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:18:59+00:00"
+            "time": "2021-06-15T12:49:02+00:00"
         },
         {
             "name": "sebastian/version",
@@ -3354,16 +3355,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.20.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
@@ -3375,7 +3376,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3413,7 +3414,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.20.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -3429,7 +3430,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
@@ -4002,16 +4003,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
@@ -4040,7 +4041,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/master"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
             },
             "funding": [
                 {
@@ -4048,7 +4049,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-07-12T23:59:07+00:00"
+            "time": "2021-07-28T10:34:58+00:00"
         },
         {
             "name": "vimeo/psalm",
@@ -4320,7 +4321,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4 || ~8.0.0"
+        "php": ">=7.4, <8.2"
     },
     "platform-dev": {
         "ext-phar": "*"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,6 +10,9 @@
     <exclude-pattern>*/_files/*</exclude-pattern>
 
     <rule ref="LaminasCodingStandard">
+        <!-- This rule is deprecated and produces false positives. -->
+        <exclude name="SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse"/>
+
         <!-- non-strict comparisons are used in a lot of legacy code, and must be removed with care and additional
              testing. For now, we accept that it exists in the codebase -->
         <exclude name="SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedEqualOperator"/>

--- a/psalm.xml
+++ b/psalm.xml
@@ -41,6 +41,13 @@
                 <referencedMethod name="Laminas\Code\Scanner\DocBlockScanner::getTags"/>
             </errorLevel>
         </InternalMethod>
+
+        <UndefinedAttributeClass>
+            <errorLevel type="suppress">
+                <!-- This class has been added in PHP 8.1 and Psalm does not know it yet. -->
+                <referencedClass name="ReturnTypeWillChange"/>
+            </errorLevel>
+        </UndefinedAttributeClass>
     </issueHandlers>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -3,6 +3,7 @@
 namespace Laminas\Code\Reflection;
 
 use ReflectionClass;
+use ReturnTypeWillChange;
 
 use function array_shift;
 use function array_slice;
@@ -44,6 +45,7 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
      * @param  bool $includeDocComment
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function getStartLine($includeDocComment = false)
     {
         if ($includeDocComment && $this->getDocComment() != '') {
@@ -83,6 +85,7 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
      *
      * @return ClassReflection[]
      */
+    #[ReturnTypeWillChange]
     public function getInterfaces()
     {
         $phpReflections     = parent::getInterfaces();
@@ -103,6 +106,7 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
      * @param  string $name
      * @return MethodReflection
      */
+    #[ReturnTypeWillChange]
     public function getMethod($name)
     {
         return new MethodReflection($this->getName(), parent::getMethod($name)->getName());
@@ -114,6 +118,7 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
      * @param  int $filter
      * @return MethodReflection[]
      */
+    #[ReturnTypeWillChange]
     public function getMethods($filter = -1)
     {
         $methods = [];
@@ -130,6 +135,7 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
      *
      * @return null|array
      */
+    #[ReturnTypeWillChange]
     public function getTraits()
     {
         $vals   = [];
@@ -150,6 +156,7 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
      *
      * @return ClassReflection|bool
      */
+    #[ReturnTypeWillChange]
     public function getParentClass()
     {
         $phpReflection = parent::getParentClass();
@@ -169,6 +176,7 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
      * @param  string $name
      * @return PropertyReflection
      */
+    #[ReturnTypeWillChange]
     public function getProperty($name)
     {
         $phpReflection     = parent::getProperty($name);
@@ -184,6 +192,7 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
      * @param  int $filter
      * @return PropertyReflection[]
      */
+    #[ReturnTypeWillChange]
     public function getProperties($filter = -1)
     {
         $phpReflections     = parent::getProperties($filter);

--- a/src/Reflection/FunctionReflection.php
+++ b/src/Reflection/FunctionReflection.php
@@ -3,6 +3,7 @@
 namespace Laminas\Code\Reflection;
 
 use ReflectionFunction;
+use ReturnTypeWillChange;
 
 use function array_shift;
 use function array_slice;
@@ -56,6 +57,7 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
      * @param  bool $includeDocComment
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function getStartLine($includeDocComment = false)
     {
         if ($includeDocComment) {
@@ -180,6 +182,7 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
      *
      * @return ParameterReflection[]
      */
+    #[ReturnTypeWillChange]
     public function getParameters()
     {
         $phpReflections     = parent::getParameters();

--- a/src/Reflection/MethodReflection.php
+++ b/src/Reflection/MethodReflection.php
@@ -3,6 +3,7 @@
 namespace Laminas\Code\Reflection;
 
 use ReflectionMethod as PhpReflectionMethod;
+use ReturnTypeWillChange;
 
 use function array_shift;
 use function array_slice;
@@ -53,6 +54,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
      * @param  bool $includeDocComment
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function getStartLine($includeDocComment = false)
     {
         if ($includeDocComment) {
@@ -69,6 +71,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
      *
      * @return ClassReflection
      */
+    #[ReturnTypeWillChange]
     public function getDeclaringClass()
     {
         $phpReflection     = parent::getDeclaringClass();
@@ -84,6 +87,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
      * @param string $format
      * @return array|string
      */
+    #[ReturnTypeWillChange]
     public function getPrototype($format = self::PROTOTYPE_AS_ARRAY)
     {
         $returnType = 'mixed';
@@ -140,6 +144,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
      *
      * @return ParameterReflection[]
      */
+    #[ReturnTypeWillChange]
     public function getParameters()
     {
         $phpReflections     = parent::getParameters();

--- a/src/Reflection/ParameterReflection.php
+++ b/src/Reflection/ParameterReflection.php
@@ -5,6 +5,7 @@ namespace Laminas\Code\Reflection;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionParameter;
+use ReturnTypeWillChange;
 
 use function method_exists;
 
@@ -18,6 +19,7 @@ class ParameterReflection extends ReflectionParameter implements ReflectionInter
      *
      * @return ClassReflection
      */
+    #[ReturnTypeWillChange]
     public function getDeclaringClass()
     {
         $phpReflection     = parent::getDeclaringClass();
@@ -32,6 +34,7 @@ class ParameterReflection extends ReflectionParameter implements ReflectionInter
      *
      * @return null|ClassReflection
      */
+    #[ReturnTypeWillChange]
     public function getClass()
     {
         $phpReflectionType = parent::getType();
@@ -50,6 +53,7 @@ class ParameterReflection extends ReflectionParameter implements ReflectionInter
      *
      * @return FunctionReflection|MethodReflection
      */
+    #[ReturnTypeWillChange]
     public function getDeclaringFunction()
     {
         $phpReflection = parent::getDeclaringFunction();

--- a/src/Reflection/PropertyReflection.php
+++ b/src/Reflection/PropertyReflection.php
@@ -3,6 +3,7 @@
 namespace Laminas\Code\Reflection;
 
 use ReflectionProperty as PhpReflectionProperty;
+use ReturnTypeWillChange;
 
 /**
  * @todo       implement line numbers
@@ -14,6 +15,7 @@ class PropertyReflection extends PhpReflectionProperty implements ReflectionInte
      *
      * @return ClassReflection
      */
+    #[ReturnTypeWillChange]
     public function getDeclaringClass()
     {
         $phpReflection     = parent::getDeclaringClass();
@@ -28,6 +30,7 @@ class PropertyReflection extends PhpReflectionProperty implements ReflectionInte
      *
      * @return string|false False if no DocBlock defined
      */
+    #[ReturnTypeWillChange]
     public function getDocComment()
     {
         return parent::getDocComment();

--- a/test/Generator/ParameterGeneratorTest.php
+++ b/test/Generator/ParameterGeneratorTest.php
@@ -118,6 +118,7 @@ class ParameterGeneratorTest extends TestCase
 
     /**
      * @group 95
+     * @requires PHP < 8.1
      */
     public function testFromReflectionGetDefaultValueNotOptional()
     {

--- a/test/Reflection/ClassReflectionTest.php
+++ b/test/Reflection/ClassReflectionTest.php
@@ -88,9 +88,9 @@ class ClassReflectionTest extends TestCase
         return \$this->_prop2;
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
-        return [];
+        return new \EmptyIterator();
     }
 
 }
@@ -121,9 +121,9 @@ EOS;
         return \$this->_prop2;
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
-        return [];
+        return new \EmptyIterator();
     }
 
 }

--- a/test/Reflection/TestAsset/TestSampleClass2.php
+++ b/test/Reflection/TestAsset/TestSampleClass2.php
@@ -23,9 +23,9 @@ class TestSampleClass2 implements \IteratorAggregate
         return $this->_prop2;
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
-        return [];
+        return new \EmptyIterator();
     }
 
 }

--- a/test/Reflection/TestAsset/TestSampleClass9.php
+++ b/test/Reflection/TestAsset/TestSampleClass9.php
@@ -25,9 +25,9 @@ class TestSampleClass9
         return $this->_prop2;
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
-        return [];
+        return new \EmptyIterator();
     }
 
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

PHP 8.1 will introduce a process to add return types to internal methods, see https://wiki.php.net/rfc/internal_method_return_types

This library extends various reflection classes and overrides public methods that are affected by this change. PHP 8.1 triggers deprecation warnings unless we declare that a future version of this library will add these return types as well. We can do so by adding the `ReturnTypeWillChange` attribute to those methods.

This PR suggests to do just that because adding the actual return types would break code that extends our classes. A potential version 5 of this library could then add the actual return types.

There is one problematic case though: `MethodReflection::getPrototype()`. That method as it is currently implemented will return an array or string, depending on a parameter passed to it. The parent method `ReflectionMethod::getPrototype()` however will return a `ReflectionMethod` instance.

My recommended course of action would be to introduce two new methods `getPrototypeAsString()` and `getPrototypeAsArray()` and deprecate calling `MethodReflection::getPrototype()` with the `PROTOTYPE_AS_ARRAY`/`PROTOTYPE_AS_STRING` parameter.

If you agree with that, I could work on a follow-up PR.