### PR TITLE
Pass `0` instead of `null` to `preg_match()` `$flags`, since in PHP 8.1+ the signature may change

### DIFF
--- a/src/Scanner/DocBlockScanner.php
+++ b/src/Scanner/DocBlockScanner.php
@@ -176,7 +176,7 @@ class DocBlockScanner
             }
             $currentChar = $stream[$streamIndex];
             $matches     = [];
-            $currentLine = preg_match('#(.*?)\r?\n#', $stream, $matches, null, $streamIndex) === 1
+            $currentLine = preg_match('#(.*?)\r?\n#', $stream, $matches, 0, $streamIndex) === 1
                 ? $matches[1]
                 : substr($stream, $streamIndex);
             if ($currentChar === ' ') {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The `$flags` parameter of `preg_match()` should be an integer, but `DocBlockScanner` passes `null` when calling the method. PHP 8.1 will be stricter about that and trigger a deprecation warning. This PR proposes to pass `0` instead, which is the actual default value of that parameter.