### PR TITLE
Fix `MethodGenerator` parameter sorting, when an explicit sorting is provided

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1590,10 +1590,10 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$className</code>
     </ArgumentTypeCoercion>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument occurrences="2">
       <code>new stdClass()</code>
     </InvalidArgument>
-    <MissingReturnType occurrences="20">
+    <MissingReturnType occurrences="21">
       <code>testByRefReturnType</code>
       <code>testCopyMethodSignature</code>
       <code>testCreateFromArray</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1590,10 +1590,10 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$className</code>
     </ArgumentTypeCoercion>
-    <InvalidArgument occurrences="2">
+    <InvalidArgument occurrences="1">
       <code>new stdClass()</code>
     </InvalidArgument>
-    <MissingReturnType occurrences="21">
+    <MissingReturnType occurrences="22">
       <code>testByRefReturnType</code>
       <code>testCopyMethodSignature</code>
       <code>testCreateFromArray</code>
@@ -1609,6 +1609,8 @@
       <code>testMethodFromReflectionMultiLinesIndention</code>
       <code>testMethodParameterAccessors</code>
       <code>testMethodParameterMutator</code>
+      <code>testSetMethodParameter</code>
+      <code>testSetMethodParameters</code>
       <code>testMethodWithFinalModifierIsEmitted</code>
       <code>testMethodWithFinalModifierIsNotEmittedWhenMethodIsAbstract</code>
       <code>testMethodWithStaticModifierIsEmitted</code>

--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -15,6 +15,7 @@ use function strlen;
 use function strtolower;
 use function substr;
 use function trim;
+use function usort;
 
 class MethodGenerator extends AbstractMemberGenerator
 {

--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -318,6 +318,7 @@ class MethodGenerator extends AbstractMemberGenerator
 
     /**
      * Sort parameters by their position
+     * @return void
      */
     protected function sortParameters()
     {

--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -312,10 +312,8 @@ class MethodGenerator extends AbstractMemberGenerator
 
     /**
      * Sort parameters by their position
-     *
-     * @return void
      */
-    protected function sortParameters()
+    private function sortParameters(): void
     {
         usort($this->parameters, static function (ParameterGenerator $item1, ParameterGenerator $item2) {
             return $item1->getPosition() <=> $item2->getPosition();

--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -30,8 +30,6 @@ class MethodGenerator extends AbstractMemberGenerator
 
     private bool $returnsReference = false;
 
-    private bool $sortParametersOnSet = true;
-
     /**
      * @return MethodGenerator
      */
@@ -215,13 +213,10 @@ class MethodGenerator extends AbstractMemberGenerator
      */
     public function setParameters(array $parameters)
     {
-        $this->sortParametersOnSet = false;
-
         foreach ($parameters as $parameter) {
             $this->setParameter($parameter);
         }
 
-        $this->sortParametersOnSet = true;
         $this->sortParameters();
 
         return $this;
@@ -252,9 +247,8 @@ class MethodGenerator extends AbstractMemberGenerator
 
         $this->parameters[$parameter->getName()] = $parameter;
 
-        if ($this->sortParametersOnSet) {
-            $this->sortParameters();
-        }
+        $this->sortParameters();
+
         return $this;
     }
 

--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -29,6 +29,8 @@ class MethodGenerator extends AbstractMemberGenerator
 
     private bool $returnsReference = false;
 
+    private bool $sortParametersOnSet = true;
+
     /**
      * @return MethodGenerator
      */
@@ -212,9 +214,14 @@ class MethodGenerator extends AbstractMemberGenerator
      */
     public function setParameters(array $parameters)
     {
+        $this->sortParametersOnSet = false;
+
         foreach ($parameters as $parameter) {
             $this->setParameter($parameter);
         }
+
+        $this->sortParametersOnSet = true;
+        $this->sortParameters();
 
         return $this;
     }
@@ -244,6 +251,9 @@ class MethodGenerator extends AbstractMemberGenerator
 
         $this->parameters[$parameter->getName()] = $parameter;
 
+        if ($this->sortParametersOnSet) {
+            $this->sortParameters();
+        }
         return $this;
     }
 
@@ -303,6 +313,16 @@ class MethodGenerator extends AbstractMemberGenerator
         $this->returnsReference = (bool) $returnsReference;
 
         return $this;
+    }
+
+    /**
+     * Sort parameters by their position
+     */
+    protected function sortParameters()
+    {
+        usort($this->parameters, static function (ParameterGenerator $item1, ParameterGenerator $item2) {
+            return $item1->getPosition() <=> $item2->getPosition();
+        });
     }
 
     /**

--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -318,6 +318,7 @@ class MethodGenerator extends AbstractMemberGenerator
 
     /**
      * Sort parameters by their position
+     *
      * @return void
      */
     protected function sortParameters()

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function array_filter;
+use function array_map;
 use function array_shift;
 use function array_values;
 
@@ -74,7 +75,22 @@ class MethodGeneratorTest extends TestCase
         $methodGenerator->setParameter(new stdClass());
     }
 
-    public function testMethodParameterSetPosition()
+    public function testSetMethodParameter()
+    {
+        $methodGenerator = new MethodGenerator();
+
+        $methodGenerator->setParameter('foo');
+
+        $params = $methodGenerator->getParameters();
+        self::assertCount(1, $params);
+
+        /** @var ParameterGenerator $foo */
+        $foo = array_shift($params);
+        self::assertInstanceOf(ParameterGenerator::class, $foo);
+        self::assertSame('foo', $foo->getName());
+    }
+
+    public function testSetMethodParameters()
     {
         $methodGenerator = new MethodGenerator();
 
@@ -85,25 +101,12 @@ class MethodGeneratorTest extends TestCase
         );
 
         $params = $methodGenerator->getParameters();
-        self::assertCount(3, $params);
 
-        /** @var ParameterGenerator $foo */
-        $foo = array_shift($params);
-        self::assertInstanceOf(ParameterGenerator::class, $foo);
-        self::assertSame('foo', $foo->getName());
+        $sorting = array_map(static function (ParameterGenerator $parameter): string {
+            return $parameter->getName();
+        }, $params);
 
-        $bar = array_shift($params);
-        self::assertEquals(
-            ParameterGenerator::fromArray(['name' => 'baz', 'type' => stdClass::class, 'position' => 1]),
-            $bar
-        );
-
-        /** @var ParameterGenerator $baz */
-        $baz = array_shift($params);
-        self::assertSame('bar', $baz->getName());
-
-        $this->expectException(InvalidArgumentException::class);
-        $methodGenerator->setParameter(new stdClass());
+        self::assertEquals(['foo', 'baz', 'bar'], $sorting);
     }
 
     public function testMethodBodyGetterAndSetter()

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -80,7 +80,9 @@ class MethodGeneratorTest extends TestCase
 
         $methodGenerator->setParameter('foo');
         $methodGenerator->setParameter(['name' => 'bar', 'type' => 'array', 'position' => 2]);
-        $methodGenerator->setParameter(ParameterGenerator::fromArray(['name' => 'baz', 'type' => stdClass::class, 'position' => 1]));
+        $methodGenerator->setParameter(
+            ParameterGenerator::fromArray(['name' => 'baz', 'type' => stdClass::class, 'position' => 1])
+        );
 
         $params = $methodGenerator->getParameters();
         self::assertCount(3, $params);
@@ -91,7 +93,10 @@ class MethodGeneratorTest extends TestCase
         self::assertSame('foo', $foo->getName());
 
         $bar = array_shift($params);
-        self::assertEquals(ParameterGenerator::fromArray(['name' => 'baz', 'type' => stdClass::class, 'position' => 1]), $bar);
+        self::assertEquals(
+            ParameterGenerator::fromArray(['name' => 'baz', 'type' => stdClass::class, 'position' => 1]),
+            $bar
+        );
 
         /** @var ParameterGenerator $baz */
         $baz = array_shift($params);

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -74,6 +74,33 @@ class MethodGeneratorTest extends TestCase
         $methodGenerator->setParameter(new stdClass());
     }
 
+    public function testMethodParameterSetPosition()
+    {
+        $methodGenerator = new MethodGenerator();
+
+        $methodGenerator->setParameter('foo');
+        $methodGenerator->setParameter(['name' => 'bar', 'type' => 'array', 'position' => 2]);
+        $methodGenerator->setParameter(ParameterGenerator::fromArray(['name' => 'baz', 'type' => stdClass::class, 'position' => 1]));
+
+        $params = $methodGenerator->getParameters();
+        self::assertCount(3, $params);
+
+        /** @var ParameterGenerator $foo */
+        $foo = array_shift($params);
+        self::assertInstanceOf(ParameterGenerator::class, $foo);
+        self::assertSame('foo', $foo->getName());
+
+        $bar = array_shift($params);
+        self::assertEquals(ParameterGenerator::fromArray(['name' => 'baz', 'type' => stdClass::class, 'position' => 1]), $bar);
+
+        /** @var ParameterGenerator $baz */
+        $baz = array_shift($params);
+        self::assertSame('bar', $baz->getName());
+
+        $this->expectException(InvalidArgumentException::class);
+        $methodGenerator->setParameter(new stdClass());
+    }
+
     public function testMethodBodyGetterAndSetter()
     {
         $method = new MethodGenerator();


### PR DESCRIPTION
The MethodGenerator doesn't seem to take any notice of the ParameterGenerator position property. This causes issues when adding properties out of order, especially with optional and variadic parameters.