### PR TITLE
Make MethodGenerator parameter sorting preserve array keys

### DIFF
--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -15,7 +15,7 @@ use function strlen;
 use function strtolower;
 use function substr;
 use function trim;
-use function usort;
+use function uasort;
 
 class MethodGenerator extends AbstractMemberGenerator
 {
@@ -315,7 +315,7 @@ class MethodGenerator extends AbstractMemberGenerator
      */
     private function sortParameters(): void
     {
-        usort($this->parameters, static function (ParameterGenerator $item1, ParameterGenerator $item2) {
+        uasort($this->parameters, static function (ParameterGenerator $item1, ParameterGenerator $item2) {
             return $item1->getPosition() <=> $item2->getPosition();
         });
     }

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -106,7 +106,7 @@ class MethodGeneratorTest extends TestCase
             return $parameter->getName();
         }, $params);
 
-        self::assertEquals(['foo', 'baz', 'bar'], $sorting);
+        self::assertEquals(['foo' => 'foo', 'baz' => 'baz', 'bar' => 'bar'], $sorting);
     }
 
     public function testMethodBodyGetterAndSetter()


### PR DESCRIPTION
The parameter sorting bug fix introduced its own bug, wherein it didn't preserve the array keys on sort. This commit patches that problem.