### PR TITLE
Add php 8 support to 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "extra": {
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "laminas/laminas-eventmanager": "^2.6 || ^3.0",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR adds PHP 8 support to the 3.4 version.
