### PR TITLE
Drop `laminas/laminas-zendframework-bridge` from suggested dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
     },
     "suggest": {
         "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
-        "laminas/laminas-stdlib": "Laminas\\Stdlib component",
-        "laminas/laminas-zendframework-bridge": "A bridge with Zend Framework"
+        "laminas/laminas-stdlib": "Laminas\\Stdlib component"
     },
     "config": {
         "sort-packages": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4375,6 +4375,7 @@
                 "issues": "https://github.com/webmozart/path-util/issues",
                 "source": "https://github.com/webmozart/path-util/tree/2.3.0"
             },
+            "abandoned": "symfony/filesystem",
             "time": "2015-12-17T08:42:14+00:00"
         }
     ],


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description


Increase performance by removing a compatibility layer while **not** introducing breaking changes.

This follow the process described in details in:

https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2021-08-02-TSC-Minutes.md#remove-laminaslaminas-zendframework-bridge-dependency-from-our-packages
