### PR TITLE
Allow setting by-reference return on methods generated via `MethodGenerator::fromArray()`, add `MethodGenerator#returnsReference()`

### DIFF
--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -118,15 +118,17 @@ class MethodGenerator extends AbstractMemberGenerator
     /**
      * Generate from array
      *
-     * @configkey name           string        [required] Class Name
-     * @configkey docblock       string        The docblock information
-     * @configkey flags          int           Flags, one of MethodGenerator::FLAG_ABSTRACT MethodGenerator::FLAG_FINAL
-     * @configkey parameters     string        Class which this class is extending
-     * @configkey body           string
-     * @configkey abstract       bool
-     * @configkey final          bool
-     * @configkey static         bool
-     * @configkey visibility     string
+     * @configkey name             string        [required] Class Name
+     * @configkey docblock         string        The DocBlock information
+     * @configkey flags            int           Flags, one of self::FLAG_ABSTRACT, self::FLAG_FINAL
+     * @configkey parameters       string        Class which this class is extending
+     * @configkey body             string
+     * @configkey returntype       string
+     * @configkey returnsreference bool
+     * @configkey abstract         bool
+     * @configkey final            bool
+     * @configkey static           bool
+     * @configkey visibility       string
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return MethodGenerator
@@ -174,6 +176,8 @@ class MethodGenerator extends AbstractMemberGenerator
                 case 'returntype':
                     $method->setReturnType($value);
                     break;
+                case 'returnsreference':
+                    $method->setReturnsReference($value);
             }
         }
 
@@ -312,6 +316,14 @@ class MethodGenerator extends AbstractMemberGenerator
         $this->returnsReference = (bool) $returnsReference;
 
         return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isReturnsReference(): bool
+    {
+        return $this->returnsReference;
     }
 
     /**

--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -318,9 +318,6 @@ class MethodGenerator extends AbstractMemberGenerator
         return $this;
     }
 
-    /**
-     * @return bool
-     */
     public function isReturnsReference(): bool
     {
         return $this->returnsReference;

--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -177,7 +177,7 @@ class MethodGenerator extends AbstractMemberGenerator
                     $method->setReturnType($value);
                     break;
                 case 'returnsreference':
-                    $method->setReturnsReference($value);
+                    $method->setReturnsReference((bool) $value);
             }
         }
 

--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -318,7 +318,7 @@ class MethodGenerator extends AbstractMemberGenerator
         return $this;
     }
 
-    public function isReturnsReference(): bool
+    public function returnsReference(): bool
     {
         return $this->returnsReference;
     }

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -296,7 +296,7 @@ EOS;
 
     public function testCreateFromArray()
     {
-        $methodGenerator = MethodGenerator::fromArray([
+        $config = [
             'name'       => 'SampleMethod',
             'body'       => 'foo',
             'docblock'   => [
@@ -307,7 +307,8 @@ EOS;
             'static'     => true,
             'visibility' => MethodGenerator::VISIBILITY_PROTECTED,
             'returntype' => '\\SampleType',
-        ]);
+        ];
+        $methodGenerator = MethodGenerator::fromArray($config);
 
         self::assertSame('SampleMethod', $methodGenerator->getName());
         self::assertSame('foo', $methodGenerator->getBody());
@@ -318,6 +319,11 @@ EOS;
         self::assertSame(MethodGenerator::VISIBILITY_PROTECTED, $methodGenerator->getVisibility());
         self::assertInstanceOf(TypeGenerator::class, $methodGenerator->getReturnType());
         self::assertSame('\\SampleType', $methodGenerator->getReturnType()->generate());
+        self::assertFalse($methodGenerator->isReturnsReference());
+
+        $config['returnsreference'] = true;
+        $methodGenerator = MethodGenerator::fromArray($config);
+        self::assertTrue($methodGenerator->isReturnsReference());
     }
 
     public function testCreateInterfaceMethodFromArray()

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -326,7 +326,7 @@ EOS;
      * @param bool|string|int $value
      * @param bool $expected
      */
-    public function testCreateFromArrayWithReturnsReference($value, $expected)
+    public function testCreateFromArrayWithReturnsReference($value, $expected): void
     {
         $methodGenerator = MethodGenerator::fromArray([
             'name'             => 'SampleMethod',
@@ -340,7 +340,7 @@ EOS;
      * @return string[][]
      * @psalm-return list<array{bool|string|int, bool}>
      */
-    public function returnReturnsRefeferenceValues()
+    public function returnReturnsRefeferenceValues(): array
     {
         return [
             [true, true],

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -318,11 +318,10 @@ EOS;
         self::assertSame(MethodGenerator::VISIBILITY_PROTECTED, $methodGenerator->getVisibility());
         self::assertInstanceOf(TypeGenerator::class, $methodGenerator->getReturnType());
         self::assertSame('\\SampleType', $methodGenerator->getReturnType()->generate());
-        self::assertFalse($methodGenerator->isReturnsReference());
     }
 
     /**
-     * @dataProvider returnReturnsRefeferenceValues
+     * @dataProvider returnReturnsReferenceValues
      * @param bool|string|int $value
      * @param bool $expected
      */
@@ -340,7 +339,7 @@ EOS;
      * @return string[][]
      * @psalm-return list<array{bool|string|int, bool}>
      */
-    public function returnReturnsRefeferenceValues(): array
+    public function returnReturnsReferenceValues(): array
     {
         return [
             [true, true],

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -321,7 +321,7 @@ EOS;
     }
 
     /**
-     * @dataProvider returnReturnsReferenceValues
+     * @dataProvider returnsReferenceValues
      * @param bool|string|int $value
      * @param bool $expected
      */
@@ -332,14 +332,16 @@ EOS;
             'returnsreference' => $value,
         ]);
 
-        self::assertSame($expected, $methodGenerator->isReturnsReference());
+        self::assertSame($expected, $methodGenerator->returnsReference());
     }
 
     /**
-     * @return string[][]
-     * @psalm-return list<array{bool|string|int, bool}>
+     * @return list<array{
+     *     bool|string|int,
+     *     bool
+     * }>
      */
-    public function returnReturnsReferenceValues(): array
+    public function returnsReferenceValues(): array
     {
         return [
             [true, true],

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -296,7 +296,7 @@ EOS;
 
     public function testCreateFromArray()
     {
-        $config = [
+        $methodGenerator = MethodGenerator::fromArray([
             'name'       => 'SampleMethod',
             'body'       => 'foo',
             'docblock'   => [
@@ -307,8 +307,7 @@ EOS;
             'static'     => true,
             'visibility' => MethodGenerator::VISIBILITY_PROTECTED,
             'returntype' => '\\SampleType',
-        ];
-        $methodGenerator = MethodGenerator::fromArray($config);
+        ]);
 
         self::assertSame('SampleMethod', $methodGenerator->getName());
         self::assertSame('foo', $methodGenerator->getBody());
@@ -320,10 +319,37 @@ EOS;
         self::assertInstanceOf(TypeGenerator::class, $methodGenerator->getReturnType());
         self::assertSame('\\SampleType', $methodGenerator->getReturnType()->generate());
         self::assertFalse($methodGenerator->isReturnsReference());
+    }
 
-        $config['returnsreference'] = true;
-        $methodGenerator = MethodGenerator::fromArray($config);
-        self::assertTrue($methodGenerator->isReturnsReference());
+    /**
+     * @dataProvider returnReturnsRefeferenceValues
+     * @param bool|string|int $value
+     * @param bool $expected
+     */
+    public function testCreateFromArrayWithReturnsReference($value, $expected)
+    {
+        $methodGenerator = MethodGenerator::fromArray([
+            'name'             => 'SampleMethod',
+            'returnsreference' => $value,
+        ]);
+
+        self::assertSame($expected, $methodGenerator->isReturnsReference());
+    }
+
+    /**
+     * @return string[][]
+     * @psalm-return list<array{bool|string|int, bool}>
+     */
+    public function returnReturnsRefeferenceValues()
+    {
+        return [
+            [true, true],
+            [1, true],
+            ['true', true],
+            [false, false],
+            [0, false],
+            ['', false],
+        ];
     }
 
     public function testCreateInterfaceMethodFromArray()


### PR DESCRIPTION
Fixes #119 
Fixes #107

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This adds the ability to specify a `returnsreference` input value for `MethodGenerator::fromArray()`, and makes this value accessible via `MethodGenerator#returnsReference()`.

The patch is a rebased/squashed version of #107 and then #119

Thanks @brian978 @WinterSilence! 