### PR TITLE
Add possibility to specify property types for generated properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@
 /laminas-mkdoc-theme/
 /phpunit.xml
 /vendor/
-/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /laminas-mkdoc-theme/
 /phpunit.xml
 /vendor/
+/.idea/

--- a/src/Generator/PropertyGenerator.php
+++ b/src/Generator/PropertyGenerator.php
@@ -313,11 +313,12 @@ class PropertyGenerator extends AbstractMemberGenerator
                    . ($defaultValue !== null ? $defaultValue->generate() : 'null;');
         }
 
+        $type    = $this->type;
         $output .= $this->indentation
                    . $this->getVisibility()
                    . ($this->isReadonly() ? ' readonly' : '')
                    . ($this->isStatic() ? ' static' : '')
-                   . ($this->getType() ? ' ' . $this->getType()->generate() : '')
+                   . ($type ? ' ' . $type->generate() : '')
                    . ' $' . $name;
 
         if ($this->omitDefaultValue) {

--- a/src/Generator/PropertyGenerator.php
+++ b/src/Generator/PropertyGenerator.php
@@ -3,7 +3,9 @@
 namespace Laminas\Code\Generator;
 
 use Laminas\Code\Reflection\PropertyReflection;
+
 use function array_reduce;
+use function class_exists;
 use function get_class;
 use function gettype;
 use function is_bool;
@@ -11,6 +13,7 @@ use function is_object;
 use function method_exists;
 use function sprintf;
 use function str_replace;
+use function str_starts_with;
 use function strtolower;
 
 class PropertyGenerator extends AbstractMemberGenerator
@@ -29,7 +32,6 @@ class PropertyGenerator extends AbstractMemberGenerator
     /**
      * @param  PropertyValueGenerator|string|array|null  $defaultValue
      * @param  int|int[]                                 $flags
-     * @param  string                                    $type
      */
     public function __construct(
         ?string $name = null,
@@ -111,15 +113,13 @@ class PropertyGenerator extends AbstractMemberGenerator
      * @configkey omitdefaultvalue   bool
      * @configkey readonly           bool
      * @configkey readonly           string
-     *
      * @param  array  $array
-     *
      * @return static
      * @throws Exception\InvalidArgumentException
      */
     public static function fromArray(array $array)
     {
-        if (!isset($array['name'])) {
+        if (! isset($array['name'])) {
             throw new Exception\InvalidArgumentException(
                 'Property generator requires that a name is provided for this object'
             );
@@ -158,7 +158,7 @@ class PropertyGenerator extends AbstractMemberGenerator
                     $property->omitDefaultValue($value);
                     break;
                 case 'readonly':
-                    if (!is_bool($value)) {
+                    if (! is_bool($value)) {
                         throw new Exception\InvalidArgumentException(sprintf(
                             '%s is expecting boolean on key %s. Got %s',
                             __METHOD__,
@@ -182,7 +182,6 @@ class PropertyGenerator extends AbstractMemberGenerator
 
     /**
      * @param  bool  $const
-     *
      * @return PropertyGenerator
      */
     public function setConst($const)
@@ -203,7 +202,7 @@ class PropertyGenerator extends AbstractMemberGenerator
      */
     public function isConst()
     {
-        return (bool)($this->flags & self::FLAG_CONSTANT);
+        return (bool) ($this->flags & self::FLAG_CONSTANT);
     }
 
     public function setReadonly(bool $readonly): self
@@ -221,7 +220,7 @@ class PropertyGenerator extends AbstractMemberGenerator
 
     public function isReadonly(): bool
     {
-        return (bool)($this->flags & self::FLAG_READONLY);
+        return (bool) ($this->flags & self::FLAG_READONLY);
     }
 
     /**
@@ -229,7 +228,7 @@ class PropertyGenerator extends AbstractMemberGenerator
      */
     public function setFlags($flags)
     {
-        $flags = array_reduce((array)$flags, static function (int $a, int $b): int {
+        $flags = array_reduce((array) $flags, static function (int $a, int $b): int {
             return $a | $b;
         }, 0);
 
@@ -256,7 +255,6 @@ class PropertyGenerator extends AbstractMemberGenerator
      * @param  PropertyValueGenerator|mixed  $defaultValue
      * @param  string                        $defaultValueType
      * @param  string                        $defaultValueOutputMode
-     *
      * @return static
      */
     public function setDefaultValue(
@@ -264,7 +262,7 @@ class PropertyGenerator extends AbstractMemberGenerator
         $defaultValueType = PropertyValueGenerator::TYPE_AUTO,
         $defaultValueOutputMode = PropertyValueGenerator::OUTPUT_MULTIPLE_LINE
     ) {
-        if (!$defaultValue instanceof PropertyValueGenerator) {
+        if (! $defaultValue instanceof PropertyValueGenerator) {
             $defaultValue = new PropertyValueGenerator($defaultValue, $defaultValueType, $defaultValueOutputMode);
         }
 
@@ -291,7 +289,7 @@ class PropertyGenerator extends AbstractMemberGenerator
         }
 
         if ($this->isConst()) {
-            if ($defaultValue !== null && !$defaultValue->isValidConstantType()) {
+            if ($defaultValue !== null && ! $defaultValue->isValidConstantType()) {
                 throw new Exception\RuntimeException(sprintf(
                     'The property %s is said to be '
                     . 'constant but does not have a valid constant value.',
@@ -332,20 +330,14 @@ class PropertyGenerator extends AbstractMemberGenerator
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getType(): ?string
     {
         return $this->type;
     }
 
-    /**
-     * @param  string|null  $type
-     */
     public function setType(?string $type): void
     {
-        if (class_exists($type) && !str_starts_with($type, '\\')) {
+        if (class_exists($type) && ! str_starts_with($type, '\\')) {
             $type = '\\' . $type;
         }
         $this->type = $type;

--- a/src/Generator/PropertyGenerator.php
+++ b/src/Generator/PropertyGenerator.php
@@ -54,7 +54,7 @@ class PropertyGenerator extends AbstractMemberGenerator
     }
 
     /** @return static */
-    public static function fromReflection(PropertyReflection $reflectionProperty, bool $enablePropertyTypeHint = false)
+    public static function fromReflection(PropertyReflection $reflectionProperty)
     {
         $property = new static();
 
@@ -88,7 +88,7 @@ class PropertyGenerator extends AbstractMemberGenerator
             $property->setVisibility(self::VISIBILITY_PUBLIC);
         }
 
-        if ($enablePropertyTypeHint && $reflectionProperty->getType()) {
+        if ($reflectionProperty->getType()) {
             if (
                 $typeGenerator = TypeGenerator::fromReflectionType(
                     $reflectionProperty->getType(),

--- a/src/Generator/PropertyGenerator.php
+++ b/src/Generator/PropertyGenerator.php
@@ -324,7 +324,7 @@ class PropertyGenerator extends AbstractMemberGenerator
                    . $this->getVisibility()
                    . ($this->isReadonly() ? ' readonly' : '')
                    . ($this->isStatic() ? ' static' : '')
-                   . ($this->getType() ? ' ' . (string) $this->getType() : '')
+                   . ($this->getType() ? ' ' . $this->getType()->generate() : '')
                    . ' $' . $name;
 
         if ($this->omitDefaultValue) {

--- a/src/Generator/PropertyGenerator.php
+++ b/src/Generator/PropertyGenerator.php
@@ -54,7 +54,7 @@ class PropertyGenerator extends AbstractMemberGenerator
     }
 
     /** @return static */
-    public static function fromReflection(PropertyReflection $reflectionProperty)
+    public static function fromReflection(PropertyReflection $reflectionProperty, bool $enablePropertyTypeHint = false)
     {
         $property = new static();
 
@@ -88,7 +88,7 @@ class PropertyGenerator extends AbstractMemberGenerator
             $property->setVisibility(self::VISIBILITY_PUBLIC);
         }
 
-        if ($reflectionProperty->getType()) {
+        if ($enablePropertyTypeHint && $reflectionProperty->getType()) {
             if (
                 $typeGenerator = TypeGenerator::fromReflectionType(
                     $reflectionProperty->getType(),

--- a/src/Generator/PropertyGenerator.php
+++ b/src/Generator/PropertyGenerator.php
@@ -14,6 +14,7 @@ use function method_exists;
 use function sprintf;
 use function str_replace;
 use function str_starts_with;
+use function strpos;
 use function strtolower;
 
 class PropertyGenerator extends AbstractMemberGenerator
@@ -337,7 +338,7 @@ class PropertyGenerator extends AbstractMemberGenerator
 
     public function setType(?string $type): void
     {
-        if (class_exists($type) && ! str_starts_with($type, '\\')) {
+        if (class_exists($type) && ! (0 === strpos($type, '\\'))) {
             $type = '\\' . $type;
         }
         $this->type = $type;

--- a/src/Generator/PropertyGenerator.php
+++ b/src/Generator/PropertyGenerator.php
@@ -5,16 +5,13 @@ namespace Laminas\Code\Generator;
 use Laminas\Code\Reflection\PropertyReflection;
 
 use function array_reduce;
-use function class_exists;
 use function get_class;
 use function gettype;
 use function is_bool;
 use function is_object;
-use function is_string;
 use function method_exists;
 use function sprintf;
 use function str_replace;
-use function strpos;
 use function strtolower;
 
 class PropertyGenerator extends AbstractMemberGenerator
@@ -24,7 +21,7 @@ class PropertyGenerator extends AbstractMemberGenerator
 
     protected bool $isConst = false;
 
-    protected ?string $type = null;
+    protected ?TypeGenerator $type = null;
 
     protected ?PropertyValueGenerator $defaultValue = null;
 
@@ -38,7 +35,7 @@ class PropertyGenerator extends AbstractMemberGenerator
         ?string $name = null,
         $defaultValue = null,
         $flags = self::FLAG_PUBLIC,
-        ?string $type = null
+        ?TypeGenerator $type = null
     ) {
         parent::__construct();
 
@@ -98,7 +95,7 @@ class PropertyGenerator extends AbstractMemberGenerator
                     $reflectionProperty->getDeclaringClass()
                 )
             ) {
-                    $property->setType($typeGenerator->generate());
+                $property->setType($typeGenerator);
             }
         }
 
@@ -120,7 +117,7 @@ class PropertyGenerator extends AbstractMemberGenerator
      * @configkey visibility         string
      * @configkey omitdefaultvalue   bool
      * @configkey readonly           bool
-     * @configkey type               string
+     * @configkey type               null|TypeGenerator
      * @param  array  $array
      * @return static
      * @throws Exception\InvalidArgumentException
@@ -180,14 +177,13 @@ class PropertyGenerator extends AbstractMemberGenerator
                     $property->setReadonly($value);
                     break;
                 case 'type':
-                    if (! is_string($value)) {
+                    if (! $value instanceof TypeGenerator) {
                         throw new Exception\InvalidArgumentException(sprintf(
-                            '%s is expecting string on key %s. Got %s',
+                            '%s is expecting %s on key %s. Got %s',
                             __METHOD__,
+                            TypeGenerator::class,
                             $name,
-                            is_object($value)
-                                ? get_class($value)
-                                : gettype($value)
+                            is_object($value) ? get_class($value) : gettype($value)
                         ));
                     }
                     $property->setType($value);
@@ -348,16 +344,13 @@ class PropertyGenerator extends AbstractMemberGenerator
         return $this;
     }
 
-    public function getType(): ?string
+    public function getType(): ?TypeGenerator
     {
         return $this->type;
     }
 
-    public function setType(string $type): void
+    public function setType(TypeGenerator $type): void
     {
-        if (class_exists($type) && ! (0 === strpos($type, '\\'))) {
-            $type = '\\' . $type;
-        }
         $this->type = $type;
     }
 }

--- a/src/Generator/PropertyGenerator.php
+++ b/src/Generator/PropertyGenerator.php
@@ -48,9 +48,8 @@ class PropertyGenerator extends AbstractMemberGenerator
         if ($flags !== self::FLAG_PUBLIC) {
             $this->setFlags($flags);
         }
-        if (null !== $type) {
-            $this->setType($type);
-        }
+
+        $this->type = $type;
     }
 
     /** @return static */
@@ -88,16 +87,10 @@ class PropertyGenerator extends AbstractMemberGenerator
             $property->setVisibility(self::VISIBILITY_PUBLIC);
         }
 
-        if ($reflectionProperty->getType()) {
-            if (
-                $typeGenerator = TypeGenerator::fromReflectionType(
-                    $reflectionProperty->getType(),
-                    $reflectionProperty->getDeclaringClass()
-                )
-            ) {
-                $property->setType($typeGenerator);
-            }
-        }
+        $property->setType(TypeGenerator::fromReflectionType(
+            $reflectionProperty->getType(),
+            $reflectionProperty->getDeclaringClass()
+        ));
 
         $property->setSourceDirty(false);
 
@@ -349,7 +342,7 @@ class PropertyGenerator extends AbstractMemberGenerator
         return $this->type;
     }
 
-    public function setType(TypeGenerator $type): void
+    public function setType(?TypeGenerator $type): void
     {
         $this->type = $type;
     }

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -8,11 +8,11 @@ use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\Exception\RuntimeException;
 use Laminas\Code\Generator\PropertyGenerator;
 use Laminas\Code\Generator\PropertyValueGenerator;
+use Laminas\Code\Generator\TypeGenerator;
 use Laminas\Code\Generator\ValueGenerator;
 use Laminas\Code\Reflection\ClassReflection;
 use Laminas\Code\Reflection\PropertyReflection;
 use LaminasTest\Code\Generator\TestAsset\ClassWithTypedProperty;
-use PHP_CodeSniffer\Tokenizers\PHP;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use stdClass;
@@ -55,7 +55,7 @@ class PropertyGeneratorTest extends TestCase
 
     /**
      * @dataProvider dataSetTypeSetValueGenerate
-     * @param mixed $value
+     * @param  mixed  $value
      */
     public function testSetTypeSetValueGenerate(string $type, $value, string $code): void
     {
@@ -69,7 +69,7 @@ class PropertyGeneratorTest extends TestCase
 
     /**
      * @dataProvider dataSetTypeSetValueGenerate
-     * @param mixed $value
+     * @param  mixed  $value
      */
     public function testSetBogusTypeSetValueGenerateUseAutoDetection(string $type, $value, string $code): void
     {
@@ -295,7 +295,7 @@ EOS;
             'static'           => true,
             'visibility'       => PropertyGenerator::VISIBILITY_PROTECTED,
             'omitdefaultvalue' => true,
-            'type'             => self::class,
+            'type'             => TypeGenerator::fromTypeString(self::class),
         ]);
 
         self::assertSame('SampleProperty', $propertyGenerator->getName());
@@ -308,7 +308,8 @@ EOS;
         self::assertTrue($propertyGenerator->isStatic());
         self::assertSame(PropertyGenerator::VISIBILITY_PROTECTED, $propertyGenerator->getVisibility());
         self::assertStringNotContainsString('default-foo', $propertyGenerator->generate());
-        self::assertEquals('\\' . self::class, $propertyGenerator->getType());
+        self::assertEquals(self::class, $propertyGenerator->getType());
+        self::assertInstanceOf(TypeGenerator::class, $propertyGenerator->getType());
         $reflectionOmitDefaultValue = new ReflectionProperty($propertyGenerator, 'omitDefaultValue');
 
         $reflectionOmitDefaultValue->setAccessible(true);
@@ -356,7 +357,7 @@ EOS;
 
     /**
      * @dataProvider dataSetTypeSetValueGenerate
-     * @param mixed $value
+     * @param  mixed  $value
      */
     public function testSetDefaultValue(string $type, $value): void
     {
@@ -415,7 +416,7 @@ EOS;
 
     public function testPropertyCanProduceTypeHinting(): void
     {
-        $codeGenProperty = new PropertyGenerator('someVal', 'value', [], 'SomeClass');
+        $codeGenProperty = new PropertyGenerator('someVal', 'value', [], TypeGenerator::fromTypeString('SomeClass'));
         self::assertSame('    public SomeClass $someVal = \'value\';', $codeGenProperty->generate());
     }
 }

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -432,4 +432,17 @@ EOS;
             'type' => 'invalidStringn',
         ]);
     }
+
+    public function testCanChangeTypeForPropertyGenerator(): void
+    {
+        $property = new PropertyGenerator('p', null, [], TypeGenerator::fromTypeString('?string'));
+        self::assertSame('    public ?string $p = null;', $property->generate());
+
+        $property->setType(null);
+        self::assertSame(
+            '    public $p = null;',
+            $property->generate(),
+            'A property type can be dropped'
+        );
+    }
 }

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -308,7 +308,7 @@ EOS;
         self::assertTrue($propertyGenerator->isStatic());
         self::assertSame(PropertyGenerator::VISIBILITY_PROTECTED, $propertyGenerator->getVisibility());
         self::assertStringNotContainsString('default-foo', $propertyGenerator->generate());
-        self::assertEquals(self::class, $propertyGenerator->getType());
+        self::assertEquals('\\'.self::class, $propertyGenerator->getType());
         $reflectionOmitDefaultValue = new ReflectionProperty($propertyGenerator, 'omitDefaultValue');
 
         $reflectionOmitDefaultValue->setAccessible(true);
@@ -410,7 +410,7 @@ EOS;
         $generator = PropertyGenerator::fromReflection($reflectionProperty);
         $code      = $generator->generate();
 
-        self::assertSame('    public readonly $readonly;', $code);
+        self::assertSame('    public readonly string $readonly;', $code);
     }
 
     public function testPropertyCanProduceTypeHinting(): void

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -391,16 +391,6 @@ EOS;
         $this->assertSame('    public static $fooStaticProperty;', $code);
     }
 
-    public function testFromReflectionOmitsTypeHintInTypedPropertyByDefault(): void
-    {
-        $reflectionProperty = new PropertyReflection(ClassWithTypedProperty::class, 'typedProperty');
-
-        $generator = PropertyGenerator::fromReflection($reflectionProperty);
-        $code      = $generator->generate();
-
-        self::assertSame('    private $typedProperty;', $code);
-    }
-
     public function testFromReflectionWithTypeHintInTypedProperty(): void
     {
         $reflectionProperty = new PropertyReflection(ClassWithTypedProperty::class, 'typedProperty');
@@ -423,7 +413,7 @@ EOS;
         $generator = PropertyGenerator::fromReflection($reflectionProperty);
         $code      = $generator->generate();
 
-        self::assertSame('    public readonly $readonly;', $code);
+        self::assertSame('    public readonly string $readonly;', $code);
     }
 
     public function testPropertyCanProduceTypeHinting(): void

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -423,7 +423,7 @@ EOS;
         $generator = PropertyGenerator::fromReflection($reflectionProperty);
         $code      = $generator->generate();
 
-        self::assertSame('    public readonly string $readonly;', $code);
+        self::assertSame('    public readonly $readonly;', $code);
     }
 
     public function testPropertyCanProduceTypeHinting(): void

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -419,7 +419,7 @@ EOS;
     public function testPropertyCanProduceTypeHinting(): void
     {
         $codeGenProperty = new PropertyGenerator('someVal', 'value', [], TypeGenerator::fromTypeString('SomeClass'));
-        self::assertSame('    public SomeClass $someVal = \'value\';', $codeGenProperty->generate());
+        self::assertSame('    public \SomeClass $someVal = \'value\';', $codeGenProperty->generate());
     }
 
     public function testFromArrayWithIncorrectTypePassed(): void

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -295,6 +295,7 @@ EOS;
             'static'           => true,
             'visibility'       => PropertyGenerator::VISIBILITY_PROTECTED,
             'omitdefaultvalue' => true,
+            'type'             => self::class
         ]);
 
         self::assertSame('SampleProperty', $propertyGenerator->getName());
@@ -307,7 +308,7 @@ EOS;
         self::assertTrue($propertyGenerator->isStatic());
         self::assertSame(PropertyGenerator::VISIBILITY_PROTECTED, $propertyGenerator->getVisibility());
         self::assertStringNotContainsString('default-foo', $propertyGenerator->generate());
-
+        self::assertEquals('\\LaminasTest\\Code\\Generator\\PropertyGeneratorTest',$propertyGenerator->getType());
         $reflectionOmitDefaultValue = new ReflectionProperty($propertyGenerator, 'omitDefaultValue');
 
         $reflectionOmitDefaultValue->setAccessible(true);
@@ -387,14 +388,14 @@ EOS;
         $this->assertSame('    public static $fooStaticProperty;', $code);
     }
 
-    public function testFromReflectionOmitsTypeHintInTypedProperty(): void
+    public function testFromReflectionWithTypeHintInTypedProperty(): void
     {
         $reflectionProperty = new PropertyReflection(ClassWithTypedProperty::class, 'typedProperty');
 
         $generator = PropertyGenerator::fromReflection($reflectionProperty);
         $code      = $generator->generate();
 
-        self::assertSame('    private $typedProperty;', $code);
+        self::assertSame('    private string $typedProperty;', $code);
     }
 
     /** @requires PHP >= 8.1 */
@@ -410,5 +411,11 @@ EOS;
         $code      = $generator->generate();
 
         self::assertSame('    public readonly $readonly;', $code);
+    }
+
+    public function testPropertyCanProduceTypeHinting(): void
+    {
+        $codeGenProperty = new PropertyGenerator('someVal', 'value',[],'SomeClass');
+        self::assertSame('    public SomeClass $someVal = \'value\';', $codeGenProperty->generate());
     }
 }

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -395,7 +395,7 @@ EOS;
     {
         $reflectionProperty = new PropertyReflection(ClassWithTypedProperty::class, 'typedProperty');
 
-        $generator = PropertyGenerator::fromReflection($reflectionProperty, true);
+        $generator = PropertyGenerator::fromReflection($reflectionProperty);
         $code      = $generator->generate();
 
         self::assertSame('    private string $typedProperty;', $code);

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -295,7 +295,7 @@ EOS;
             'static'           => true,
             'visibility'       => PropertyGenerator::VISIBILITY_PROTECTED,
             'omitdefaultvalue' => true,
-            'type'             => self::class
+            'type'             => self::class,
         ]);
 
         self::assertSame('SampleProperty', $propertyGenerator->getName());
@@ -308,7 +308,7 @@ EOS;
         self::assertTrue($propertyGenerator->isStatic());
         self::assertSame(PropertyGenerator::VISIBILITY_PROTECTED, $propertyGenerator->getVisibility());
         self::assertStringNotContainsString('default-foo', $propertyGenerator->generate());
-        self::assertEquals('\\LaminasTest\\Code\\Generator\\PropertyGeneratorTest',$propertyGenerator->getType());
+        self::assertEquals(self::class, $propertyGenerator->getType());
         $reflectionOmitDefaultValue = new ReflectionProperty($propertyGenerator, 'omitDefaultValue');
 
         $reflectionOmitDefaultValue->setAccessible(true);
@@ -415,7 +415,7 @@ EOS;
 
     public function testPropertyCanProduceTypeHinting(): void
     {
-        $codeGenProperty = new PropertyGenerator('someVal', 'value',[],'SomeClass');
+        $codeGenProperty = new PropertyGenerator('someVal', 'value', [], 'SomeClass');
         self::assertSame('    public SomeClass $someVal = \'value\';', $codeGenProperty->generate());
     }
 }

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -308,7 +308,7 @@ EOS;
         self::assertTrue($propertyGenerator->isStatic());
         self::assertSame(PropertyGenerator::VISIBILITY_PROTECTED, $propertyGenerator->getVisibility());
         self::assertStringNotContainsString('default-foo', $propertyGenerator->generate());
-        self::assertEquals('\\'.self::class, $propertyGenerator->getType());
+        self::assertEquals('\\' . self::class, $propertyGenerator->getType());
         $reflectionOmitDefaultValue = new ReflectionProperty($propertyGenerator, 'omitDefaultValue');
 
         $reflectionOmitDefaultValue->setAccessible(true);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | yes
| QA            | yes

### Description

Fixes #122

RFC: https://discourse.laminas.dev/t/rfc-laminas-laminas-code-add-type-hinting-option-in-propertygenerator/2652
