### PR TITLE
Fixed deprecated `null` parameter in `trim()` call

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -15,7 +15,7 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "8.0"
+          - "8.1"
         operating-system:
           - "ubuntu-latest"
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,6 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
+         convertDeprecationsToExceptions="true"
          colors="true">
     <testsuites>
         <testsuite name="laminas-code Test Suite">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -103,6 +103,9 @@
     <PossiblyNullOperand occurrences="1">
       <code>$namespaceAlias</code>
     </PossiblyNullOperand>
+    <RedundantCondition occurrences="1">
+      <code>method_exists($constReflection, 'isFinal')</code>
+    </RedundantCondition>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>is_array($constant)</code>
     </RedundantConditionGivenDocblockType>
@@ -278,9 +281,6 @@
       <code>getName</code>
       <code>getName</code>
     </MixedMethodCall>
-    <UndefinedClass occurrences="1">
-      <code>ReflectionEnumUnitCase</code>
-    </UndefinedClass>
     <UndefinedMethod occurrences="3">
       <code>getBackingType</code>
       <code>getCases</code>
@@ -367,9 +367,10 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/Generator/MethodGenerator.php">
-    <MixedArgument occurrences="12">
+    <MixedArgument occurrences="13">
       <code>$array['name']</code>
       <code>$parameterOutput</code>
+      <code>$reflectionMethod-&gt;isStatic()</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
@@ -459,6 +460,9 @@
     <PossiblyFalseArgument occurrences="1">
       <code>$reflectionProperty-&gt;getDocBlock()</code>
     </PossiblyFalseArgument>
+    <RedundantCondition occurrences="1">
+      <code>method_exists($reflectionProperty, 'isReadonly')</code>
+    </RedundantCondition>
     <UnsafeInstantiation occurrences="2">
       <code>new static($array['name'])</code>
       <code>new static()</code>
@@ -592,18 +596,14 @@
     </MissingReturnType>
   </file>
   <file src="src/Generator/TypeGenerator.php">
-    <ImpureMethodCall occurrences="4">
+    <ImpureMethodCall occurrences="5">
       <code>allowsNull</code>
       <code>getName</code>
       <code>getName</code>
       <code>getParentClass</code>
+      <code>getTypes</code>
     </ImpureMethodCall>
-    <MixedArgument occurrences="2"/>
-    <TypeDoesNotContainType occurrences="1"/>
-    <UndefinedClass occurrences="2">
-      <code>ReflectionIntersectionType</code>
-      <code>ReflectionIntersectionType</code>
-    </UndefinedClass>
+    <MixedArgument occurrences="1"/>
   </file>
   <file src="src/Generator/ValueGenerator.php">
     <DocblockTypeContradiction occurrences="1">
@@ -1086,9 +1086,6 @@
     <MixedReturnStatement occurrences="1">
       <code>$tokens</code>
     </MixedReturnStatement>
-    <PropertyNotSetInConstructor occurrences="1">
-      <code>$shortDescription</code>
-    </PropertyNotSetInConstructor>
     <RedundantCondition occurrences="2">
       <code>$context === 0x00</code>
       <code>$this-&gt;shortDescription != '' &amp;&amp; $tagIndex === null</code>
@@ -2304,14 +2301,16 @@
     </UnusedVariable>
   </file>
   <file src="test/Scanner/DocBlockScannerTest.php">
-    <InternalMethod occurrences="3">
+    <InternalMethod occurrences="4">
+      <code>new DocBlockScanner($docComment)</code>
       <code>new DocBlockScanner($docComment)</code>
       <code>new DocBlockScanner($docComment)</code>
       <code>new DocBlockScanner($docComment)</code>
     </InternalMethod>
-    <MissingReturnType occurrences="2">
+    <MissingReturnType occurrences="3">
       <code>testDocBlockScannerDescriptions</code>
       <code>testDocBlockScannerParsesTagsWithNoValuesProperly</code>
+      <code>testInvalidDocBlock</code>
     </MissingReturnType>
     <MixedArgument occurrences="2">
       <code>$tags[0]</code>

--- a/src/Scanner/DocBlockScanner.php
+++ b/src/Scanner/DocBlockScanner.php
@@ -25,7 +25,7 @@ class DocBlockScanner
     protected $docComment;
 
     /** @var string */
-    protected $shortDescription;
+    protected $shortDescription = '';
 
     /** @var string */
     protected $longDescription = '';

--- a/test/Scanner/DocBlockScannerTest.php
+++ b/test/Scanner/DocBlockScannerTest.php
@@ -51,4 +51,11 @@ EOB;
         self::assertEquals('Short Description', $tokenScanner->getShortDescription());
         self::assertEquals('Long Description continued in the second line', $tokenScanner->getLongDescription());
     }
+
+    public function testInvalidDocBlock()
+    {
+        $docComment   = '/**';
+        $tokenScanner = new DocBlockScanner($docComment);
+        self::assertEquals('', $tokenScanner->getShortDescription());
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

`DocScanner` may raise the following error with PHP 8.1 if `shortDescription` is used before initialization, the default value being `null`.

```
Exception Error: "Error: Typed property Laminas\Code\Scanner\DocBlockScanner::$shortDescription must not be accessed before initialization" in .../vendor/laminas/laminas-code/src/Scanner/DocBlockScanner.php on line 94
```
