### PR TITLE
Update `FileGenerator` reference documentation to remove `fromReflectedFilePath()`, which was removed in `4.0.0`

### DIFF
--- a/docs/book/generator/reference.md
+++ b/docs/book/generator/reference.md
@@ -264,10 +264,7 @@ The *API* of the class is as follows:
 ```php
 class Laminas\Code\Generator\FileGenerator extends Laminas\Code\Generator\AbstractGenerator
 {
-    public static function fromReflectedFilePath(
-        $filePath,
-        $usePreviousCodeGeneratorIfItExists = true,
-        $includeIfNotAlreadyIncluded = true)
+    public static function fromArray(array $values)
     public function setDocblock(Laminas\Code\Generator\DocBlockGenerator $docblock)
     public function getDocblock()
     public function setRequiredFiles($requiredFiles)


### PR DESCRIPTION
This PR is a simple documentation fix, updating FileGenerator reference. Closes  #129.

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Changes:
* Remove reference to `fromReflectedFilePath` static method;
* Add reference to `fromArray` static method.

