### PR TITLE
Value generator enum support

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -15,7 +15,7 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "7.4"
+          - "8.0"
         operating-system:
           - "ubuntu-latest"
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,7 +17,6 @@ jobs:
           - "highest"
           - "locked"
         php-version:
-          - "7.4"
           - "8.0"
           - "8.1"
         operating-system:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "homepage": "https://laminas.dev",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=7.4, <8.2"
+        "php": ">=8.0, <8.2"
     },
     "require-dev": {
         "ext-phar": "*",
@@ -29,7 +29,7 @@
             "dealerdirect/phpcodesniffer-composer-installer": true
         },
         "platform": {
-            "php": "7.4.99"
+            "php": "8.0.99"
         },
         "sort-packages": true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d114f0e2528a6bcb8103648fdcc50721",
+    "content-hash": "19b88939a630e881e0dcbcd01eb49b9e",
     "packages": [],
     "packages-dev": [
         {
@@ -4473,13 +4473,13 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4, <8.2"
+        "php": ">=8.0, <8.2"
     },
     "platform-dev": {
         "ext-phar": "*"
     },
     "platform-overrides": {
-        "php": "7.4.99"
+        "php": "8.0.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/src/Generator/FileGenerator.php
+++ b/src/Generator/FileGenerator.php
@@ -193,7 +193,7 @@ class FileGenerator extends AbstractGenerator
      *
      * @param  bool $withResolvedAs
      * @return array
-     * @psalm-return array<int, array{string, null|string, false|null|string}>
+     * @psalm-return array<int, array{string, null|string, null|string}>
      */
     public function getUses($withResolvedAs = false)
     {

--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -5,6 +5,7 @@ namespace Laminas\Code\Generator;
 use ArrayObject as SplArrayObject;
 use Laminas\Code\Exception\InvalidArgumentException;
 use Laminas\Stdlib\ArrayObject as StdlibArrayObject;
+use UnitEnum;
 
 use function addcslashes;
 use function array_keys;
@@ -43,6 +44,7 @@ class ValueGenerator extends AbstractGenerator
     public const TYPE_ARRAY_LONG  = 'array_long';
     public const TYPE_CONSTANT    = 'constant';
     public const TYPE_NULL        = 'null';
+    public const TYPE_ENUM        = 'enum';
     public const TYPE_OBJECT      = 'object';
     public const TYPE_OTHER       = 'other';
     /**#@-*/
@@ -264,6 +266,7 @@ class ValueGenerator extends AbstractGenerator
             self::TYPE_ARRAY_LONG,
             self::TYPE_CONSTANT,
             self::TYPE_NULL,
+            self::TYPE_ENUM,
             self::TYPE_OBJECT,
             self::TYPE_OTHER,
         ];
@@ -304,6 +307,10 @@ class ValueGenerator extends AbstractGenerator
             case 'NULL':
                 return self::TYPE_NULL;
             case 'object':
+                if ($value instanceof UnitEnum) {
+                    return self::TYPE_ENUM;
+                }
+                // enums are typed as objects, so this fall through is intentional
             case 'resource':
             case 'unknown type':
             default:
@@ -417,6 +424,13 @@ class ValueGenerator extends AbstractGenerator
                     $output .= self::LINE_FEED . str_repeat($this->indentation, $this->arrayDepth);
                 }
                 $output .= $endArray;
+                break;
+            case self::TYPE_ENUM:
+                if (! is_object($value)) {
+                    throw new Exception\RuntimeException('Value is not an object.');
+                }
+
+                $output = sprintf('%s::%s', get_class($value), (string) $value->name);
                 break;
             case self::TYPE_OTHER:
             default:

--- a/test/Generator/TestAsset/TestEnum.php
+++ b/test/Generator/TestAsset/TestEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace LaminasTest\Code\Generator\TestAsset;
+
+enum TestEnum
+{
+    case Test1;
+    case Test2;
+}

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -407,10 +407,14 @@ EOS;
 
         $valueGenerator1->initEnvironmentConstants();
         $valueGenerator2->initEnvironmentConstants();
+        /** @var TestEnum $value1 */
+        $value1 = $valueGenerator1->generate();
+        /** @var TestEnum $value2 */
+        $value2 = $valueGenerator2->generate();
 
-        self::assertNotEquals($valueGenerator1->generate(), $valueGenerator2->generate());
-        self::assertEquals(sprintf('%s::%s', TestEnum::class, 'Test1'), $valueGenerator1->generate());
-        self::assertEquals(sprintf('%s::%s', TestEnum::class, 'Test2'), $valueGenerator2->generate());
+        self::assertNotEquals($value1, $value2);
+        self::assertEquals(sprintf('%s::%s', TestEnum::class, 'Test1'), $value1);
+        self::assertEquals(sprintf('%s::%s', TestEnum::class, 'Test2'), $value2);
     }
 
     /**

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -12,9 +12,11 @@ use Laminas\Code\Generator\PropertyGenerator;
 use Laminas\Code\Generator\PropertyValueGenerator;
 use Laminas\Code\Generator\ValueGenerator;
 use Laminas\Stdlib\ArrayObject as StdlibArrayObject;
+use LaminasTest\Code\Generator\TestAsset\TestEnum;
 use PHPUnit\Framework\TestCase;
 
 use function fopen;
+use function sprintf;
 use function str_replace;
 
 /**
@@ -386,6 +388,29 @@ EOS;
         $valueGenerator2->initEnvironmentConstants();
 
         self::assertNotEquals($valueGenerator1->generate(), $valueGenerator2->generate());
+    }
+
+    /** @requires PHP >= 8.1 */
+    public function testPropertyDefaultValueCanHandleEnums(): void
+    {
+        $valueGenerator1 = new ValueGenerator(
+            TestEnum::Test1,
+            ValueGenerator::TYPE_AUTO,
+            ValueGenerator::OUTPUT_MULTIPLE_LINE
+        );
+
+        $valueGenerator2 = new ValueGenerator(
+            TestEnum::Test2,
+            ValueGenerator::TYPE_ENUM,
+            ValueGenerator::OUTPUT_MULTIPLE_LINE
+        );
+
+        $valueGenerator1->initEnvironmentConstants();
+        $valueGenerator2->initEnvironmentConstants();
+
+        self::assertNotEquals($valueGenerator1->generate(), $valueGenerator2->generate());
+        self::assertEquals(sprintf('%s::%s', TestEnum::class, 'Test1'), $valueGenerator1->generate());
+        self::assertEquals(sprintf('%s::%s', TestEnum::class, 'Test2'), $valueGenerator2->generate());
     }
 
     /**


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This patch enables support for enumerations in ValueGenerator, which is currently missing. It is needed to properly generate proxy classes which have enums as default values in method arguments.
