### PR TITLE
Remove superfluous trailing line in trait usage generated code

### DIFF
--- a/src/Generator/TraitUsageGenerator.php
+++ b/src/Generator/TraitUsageGenerator.php
@@ -437,6 +437,6 @@ class TraitUsageGenerator extends AbstractGenerator implements TraitUsageInterfa
             }
         }
 
-        return $output . self::LINE_FEED . $indent . '}' . self::LINE_FEED . self::LINE_FEED;
+        return $output . $indent . '}' . self::LINE_FEED . self::LINE_FEED;
     }
 }

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -1167,7 +1167,6 @@ class myClass
         hisTrait::foo as public test;
         myTrait::bar insteadof hisTrait;
         myTrait::bar insteadof thatTrait;
-
     }
 }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | no

### Description

This is a minor codestyle fix regarding the trait usage generated code when providing either aliases or replacements for a trait.

Let's consider following example script:
```php
$class = new ClassGenerator('Talker');
$class->addTrait('A');
$class->addTrait('B');
$class->addTraitAlias('B::smallTalk', 'gossip');
$class->addTraitOverride('A::bigTalk', 'B');

echo $class->generate();
```

As of now, the output will be (note the double line break after the `insteadof` statement):
```php
class Talker
{
    use A, B {
        B::smallTalk as gossip;
        A::bigTalk insteadof B;

    }
}
```

With present patch, generated code will now be:
```php
class Talker
{
    use A, B {
        B::smallTalk as gossip;
        A::bigTalk insteadof B;
    }
}
```