### PR TITLE
Add support for `readonly` classes

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -874,7 +874,7 @@
       <code>'ParentClass'</code>
       <code>['Class1', 'Class2']</code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="5"/>
+    <DeprecatedMethod occurrences="6"/>
     <InvalidArgument occurrences="6">
       <code>''</code>
       <code>'public'</code>
@@ -1291,94 +1291,6 @@
     <MissingReturnType occurrences="1">
       <code>testPropertyValueAddsSemicolonToValueGenerator</code>
     </MissingReturnType>
-  </file>
-  <file src="test/Generator/TestAsset/CallableTypeHintClass.php">
-    <MissingReturnType occurrences="1">
-      <code>foo</code>
-    </MissingReturnType>
-  </file>
-  <file src="test/Generator/TestAsset/ClassWithProperties.php">
-    <MissingPropertyType occurrences="3">
-      <code>$privateClassProperty</code>
-      <code>$protectedClassProperty</code>
-      <code>$publicClassProperty</code>
-    </MissingPropertyType>
-  </file>
-  <file src="test/Generator/TestAsset/ExtendedClassWithProperties.php">
-    <MissingPropertyType occurrences="3">
-      <code>$privateExtendedClassProperty</code>
-      <code>$protectedExtendedClassProperty</code>
-      <code>$publicExtendedClassProperty</code>
-    </MissingPropertyType>
-  </file>
-  <file src="test/Generator/TestAsset/NamespaceTypeHintClass.php">
-    <MissingReturnType occurrences="1">
-      <code>method</code>
-    </MissingReturnType>
-  </file>
-  <file src="test/Generator/TestAsset/ParameterClass.php">
-    <MissingParamType occurrences="13">
-      <code>$array</code>
-      <code>$array</code>
-      <code>$b</code>
-      <code>$baz</code>
-      <code>$con</code>
-      <code>$float</code>
-      <code>$number</code>
-      <code>$number</code>
-      <code>$param</code>
-      <code>$val</code>
-      <code>$val</code>
-      <code>$value</code>
-      <code>$value</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="16">
-      <code>defaultArray</code>
-      <code>defaultArrayWithValues</code>
-      <code>defaultConstant</code>
-      <code>defaultFalse</code>
-      <code>defaultFloat</code>
-      <code>defaultNull</code>
-      <code>defaultNumber</code>
-      <code>defaultObjectEqualsNullAndNotOptional</code>
-      <code>defaultTrue</code>
-      <code>defaultValue</code>
-      <code>defaultZero</code>
-      <code>fromArray</code>
-      <code>hasNativeDocTypes</code>
-      <code>name</code>
-      <code>reference</code>
-      <code>type</code>
-    </MissingReturnType>
-  </file>
-  <file src="test/Generator/TestAsset/TestClassWithHeredoc.php">
-    <MissingReturnType occurrences="1">
-      <code>someFunction</code>
-    </MissingReturnType>
-    <UnusedVariable occurrences="1">
-      <code>$output</code>
-    </UnusedVariable>
-  </file>
-  <file src="test/Generator/TestAsset/TestClassWithManyProperties.php">
-    <MissingPropertyType occurrences="4">
-      <code>$_barProperty</code>
-      <code>$_barStaticProperty</code>
-      <code>$_complexType</code>
-      <code>$fooStaticProperty</code>
-    </MissingPropertyType>
-  </file>
-  <file src="test/Generator/TestAsset/TestSampleSingleClass.php">
-    <InvalidReturnType occurrences="1">
-      <code>bool</code>
-    </InvalidReturnType>
-    <MissingParamType occurrences="1">
-      <code>$mixed</code>
-    </MissingParamType>
-  </file>
-  <file src="test/Generator/TestAsset/TestSampleSingleClassMultiLines.php">
-    <InvalidReturnType occurrences="1">
-      <code>bool</code>
-    </InvalidReturnType>
   </file>
   <file src="test/Generator/TraitGeneratorTest.php">
     <ArgumentTypeCoercion occurrences="1">

--- a/psalm.xml
+++ b/psalm.xml
@@ -12,6 +12,7 @@
         <directory name="test"/>
         <ignoreFiles>
             <directory name="vendor"/>
+            <directory name="test/Generator/TestAsset"/>
         </ignoreFiles>
     </projectFiles>
 

--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -33,6 +33,7 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
     public const IMPLEMENTS_KEYWORD = 'implements';
     public const FLAG_ABSTRACT      = 0x01;
     public const FLAG_FINAL         = 0x02;
+    public const FLAG_READONLY      = 0x04;
     private const CONSTRUCTOR_NAME  = '__construct';
 
     protected ?FileGenerator $containingFileGenerator = null;
@@ -88,6 +89,10 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
 
         $cg->setAbstract($classReflection->isAbstract());
         $cg->setFinal($classReflection->isFinal());
+
+        if (method_exists($classReflection, 'isReadonly')) {
+            $cg->setReadonly((bool) $classReflection->isReadonly());
+        }
 
         // set the namespace
         if ($classReflection->inNamespace()) {
@@ -421,6 +426,16 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
     public function isFinal()
     {
         return (bool) ($this->flags & self::FLAG_FINAL);
+    }
+
+    public function setReadonly(bool $isReadonly): self
+    {
+        return $isReadonly ? $this->addFlag(self::FLAG_READONLY) : $this->removeFlag(self::FLAG_READONLY);
+    }
+
+    public function isReadonly(): bool
+    {
+        return (bool) ($this->flags & self::FLAG_READONLY);
     }
 
     /**
@@ -1062,6 +1077,10 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
             $output .= 'abstract ';
         } elseif ($this->isFinal()) {
             $output .= 'final ';
+        }
+
+        if ($this->isReadonly()) {
+            $output .= 'readonly ';
         }
 
         $output .= static::OBJECT_TYPE . ' ' . $this->getName();

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -13,6 +13,7 @@ use Laminas\Code\Generator\PromotedParameterGenerator;
 use Laminas\Code\Generator\PropertyGenerator;
 use Laminas\Code\Reflection\ClassReflection;
 use LaminasTest\Code\Generator\TestAsset\ClassWithPromotedParameter;
+use LaminasTest\Code\Generator\TestAsset\ReadonlyClassWithPromotedParameter;
 use LaminasTest\Code\TestAsset\FooClass;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
@@ -1192,6 +1193,24 @@ EOS;
         self::assertSame($expectedOutput, $output, $output);
     }
 
+    public function testGenerateWithFinalReadonlyFlag(): void
+    {
+        $classGenerator = ClassGenerator::fromArray([
+            'name'  => 'SomeClass',
+            'flags' => ClassGenerator::FLAG_FINAL | ClassGenerator::FLAG_READONLY,
+        ]);
+
+        $expectedOutput = <<<EOS
+final readonly class SomeClass
+{
+}
+
+EOS;
+
+        $output = $classGenerator->generate();
+        self::assertSame($expectedOutput, $output, $output);
+    }
+
     public function testCorrectExtendNames(): void
     {
         $classGenerator = new ClassGenerator();
@@ -1420,5 +1439,27 @@ EOS;
         $classGenerator->addMethod('thisIsNoConstructor', [
             new PromotedParameterGenerator('promotedParameter', 'string'),
         ]);
+    }
+
+    /** @requires PHP >= 8.2 */
+    public function testReadonlyClassWithPromotedParameterFromReflection(): void
+    {
+        $classGenerator = ClassGenerator::fromReflection(
+            new ClassReflection(ReadonlyClassWithPromotedParameter::class)
+        );
+
+        $expectedOutput = <<<EOS
+namespace LaminasTest\Code\Generator\TestAsset;
+
+final readonly class ReadonlyClassWithPromotedParameter
+{
+    public function __construct(private string \$promotedParameter)
+    {
+    }
+}
+
+EOS;
+
+        self::assertEquals($expectedOutput, $classGenerator->generate());
     }
 }

--- a/test/Generator/TestAsset/ReadonlyClassWithPromotedParameter.php
+++ b/test/Generator/TestAsset/ReadonlyClassWithPromotedParameter.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Code\Generator\TestAsset;
+
+final readonly class ReadonlyClassWithPromotedParameter
+{
+    public function __construct(private string $promotedParameter) {
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      |no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This change adds support for `readonly` classes generation (PHP 8.2 and up).
It also adds support for `final` classes generation from `ClassReflection` (not sure why it was skipped earlier).

Added PHP 8.2 to the build matrix and `composer.json` - tests are passing.

See: #142 
