### PR TITLE
Add support for standalone `true`, `false` and `null` types

### DIFF
--- a/src/Generator/TypeGenerator/AtomicType.php
+++ b/src/Generator/TypeGenerator/AtomicType.php
@@ -42,14 +42,16 @@ final class AtomicType
         'mixed'    => 10,
         'void'     => 11,
         'false'    => 12,
-        'null'     => 13,
-        'never'    => 14,
+        'true'     => 13,
+        'null'     => 14,
+        'never'    => 15,
     ];
 
     /** @psalm-var array<non-empty-string, null> */
     private const NOT_NULLABLE_TYPES = [
         'null'  => null,
         'false' => null,
+        'true'  => null,
         'void'  => null,
         'mixed' => null,
         'never' => null,
@@ -151,6 +153,17 @@ final class AtomicType
                     $other->type
                 ));
             }
+
+            if (
+                ('true' === $other->type && 'false' === $this->type) ||
+                ('false' === $other->type && 'true' === $this->type)
+            ) {
+                throw new InvalidArgumentException(sprintf(
+                    'Type "%s" cannot be composed in a union with type "%s"',
+                    $this->type,
+                    $other->type
+                ));
+            }
         }
 
         if (
@@ -222,6 +235,6 @@ final class AtomicType
 
     private function requiresUnionWithStandaloneType(): bool
     {
-        return 'null' === $this->type || 'false' === $this->type;
+        return false;
     }
 }

--- a/test/Generator/TypeGeneratorTest.php
+++ b/test/Generator/TypeGeneratorTest.php
@@ -186,13 +186,23 @@ class TypeGeneratorTest extends TestCase
             ['null|foo', '\\foo|null'],
             ['foo|bar|null', '\\bar|\\foo|null'],
 
-            // The `false` type can only be used in combination with other types
+            // Standalone `false` type
+            ['false', 'false'],
             ['foo|false', '\\foo|false'],
             ['string|false', 'string|false'],
             ['string|false|null', 'string|false|null'],
 
             // `false` + `null` requires a third type
             ['Foo|false|null', '\\Foo|false|null'],
+
+            // The `true` type
+            ['foo|true', '\\foo|true'],
+            ['string|true', 'string|true'],
+            ['true', 'true'],
+            ['true|null', 'true|null'],
+
+            // Standalone `null` type
+            ['null', 'null'],
 
             // The `static` type should not be turned into a FQCN
             ['static', 'static'],
@@ -398,14 +408,11 @@ class TypeGeneratorTest extends TestCase
             ['never&null'],
             ['never&Foo'],
             ['never&\\foo'],
-
-            // `false` and `null` must always be used as part of a union type
-            ['null'],
-            ['false'],
             ['?null'],
-            ['?false'],
-            ['false|null'],
-            ['null|false'],
+
+            // `false` and `true` cannot be used together
+            ['true|false'],
+            ['false|true'],
 
             // Duplicate types are rejected
             ['A|A'],


### PR DESCRIPTION
Signed-off-by: Ion Bazan <ion.bazan@gmail.com>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Provides support for `true`, `false` and `null` types. 

The `false` and `null` ale no longer required to be a part of a union, therefore they can used on its own. The `requiresUnionWithStandaloneType()` method has been replaced with a simple `return false` as it is used in `assertCanBeAStandaloneType()` and `assertCanIntersectWith()` - it may be replaced in the future if needed.

See: #142 
