### PR TITLE
fix: complete ReflectionEnum polyfill

### DIFF
--- a/polyfill/ReflectionEnumPolyfill.php
+++ b/polyfill/ReflectionEnumPolyfill.php
@@ -5,10 +5,27 @@ if (\PHP_VERSION_ID >= 80100) {
 }
 
 /** @internal */
-class ReflectionEnum
+class ReflectionEnum extends \ReflectionClass
 {
-    public function __construct($enum)
+    public function __construct($objectOrClass) {}
+
+    public function hasCase(string $name): bool
+    {
+    }
+
+    public function getCases(): array
+    {
+    }
+
+    public function getCase(string $name): ReflectionEnumUnitCase
+    {
+    }
+
+    public function isBacked(): bool
+    {
+    }
+
+    public function getBackingType(): ?ReflectionType
     {
     }
 }
-

--- a/src/Generator/EnumGenerator/Cases/CaseFactory.php
+++ b/src/Generator/EnumGenerator/Cases/CaseFactory.php
@@ -10,6 +10,7 @@ use ReflectionEnumUnitCase;
 use function array_key_exists;
 use function array_map;
 use function assert;
+use function method_exists;
 
 use const PHP_VERSION_ID;
 
@@ -65,6 +66,13 @@ final class CaseFactory
             $backedCases[$singleCase->getName()] = $singleCase->getBackingValue();
         }
 
-        return BackedCases::fromCasesWithType($backedCases, $backingType->getName());
+        // PHP 8.2
+        if (method_exists($backingType, 'getName')) {
+            /** @var string $backingTypeName */
+            $backingTypeName = $backingType->getName();
+        } else {
+            $backingTypeName = (string) $backingType;
+        }
+        return BackedCases::fromCasesWithType($backedCases, $backingTypeName);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Since the polyfill is autoloaded, PHPStan seems to discover the class, even with the early return:
```
Call to an undefined method ReflectionEnum::getCases()
```

Completing this polyfill solves the issue.
