### PR TITLE
Removed dead execution branches

### DIFF
--- a/src/Generator/TypeGenerator.php
+++ b/src/Generator/TypeGenerator.php
@@ -120,8 +120,6 @@ final class TypeGenerator implements GeneratorInterface
         );
 
         if (1 === count($types)) {
-            $types[0]->assertCanBeAStandaloneType();
-
             if ($nullable) {
                 $types[0]->assertCanBeStandaloneNullable();
             }

--- a/src/Generator/TypeGenerator/AtomicType.php
+++ b/src/Generator/TypeGenerator/AtomicType.php
@@ -165,16 +165,6 @@ final class AtomicType
                 ));
             }
         }
-
-        if (
-            $this->requiresUnionWithStandaloneType() &&
-            [] === array_filter($others, static fn (self $type): bool => ! $type->requiresUnionWithStandaloneType())
-        ) {
-            throw new InvalidArgumentException(sprintf(
-                'Type "%s" requires to be composed with non-standalone types',
-                $this->type
-            ));
-        }
     }
 
     /**
@@ -199,27 +189,6 @@ final class AtomicType
                 ));
             }
         }
-
-        if (
-            $this->requiresUnionWithStandaloneType() &&
-            [] === array_filter($others, static fn (self $type): bool => ! $type->requiresUnionWithStandaloneType())
-        ) {
-            throw new InvalidArgumentException(sprintf(
-                'Type "%s" requires to be composed with non-standalone types',
-                $this->type
-            ));
-        }
-    }
-
-    /** @throws InvalidArgumentException */
-    public function assertCanBeAStandaloneType(): void
-    {
-        if ($this->requiresUnionWithStandaloneType()) {
-            throw new InvalidArgumentException(sprintf(
-                'Type "%s" cannot be used standalone, and must be part of a union type',
-                $this->type
-            ));
-        }
     }
 
     /** @throws InvalidArgumentException */
@@ -231,10 +200,5 @@ final class AtomicType
                 $this->type
             ));
         }
-    }
-
-    private function requiresUnionWithStandaloneType(): bool
-    {
-        return false;
     }
 }


### PR DESCRIPTION
Since PHP 8.2, there are no types that cannot be standalone: all types can be standalone.

This allows us to drop a bunch of code that was previously used to check if types were sound.

Signed-off-by: Marco Pivetta <ocramius@gmail.com>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

This is mostly a cleanup after #149 