### PR TITLE
Deprecating all `::fromArray()` methods in in the package

### DIFF
--- a/docs/book/generator/examples.md
+++ b/docs/book/generator/examples.md
@@ -234,7 +234,7 @@ $file = (new FileGenerator)
                 new GenericTag('license', 'New BSD')
             ])
     )
-    ->setBody('define(\'APPLICATION_ENV\', \'testing\');');
+    ->setBody("define('APPLICATION_ENV', 'testing');");
 ```
 
 Calling `generate()` will generate the code -- but not write it to a file. You will need to capture

--- a/docs/book/generator/examples.md
+++ b/docs/book/generator/examples.md
@@ -7,25 +7,20 @@ The following example generates an empty class with a class-level DocBlock.
 ```php
 use Laminas\Code\Generator\ClassGenerator;
 use Laminas\Code\Generator\DocBlockGenerator;
+use Laminas\Code\Generator\DocBlock\Tag\GenericTag;
 
-$foo      = new ClassGenerator();
-$docblock = DocBlockGenerator::fromArray([
-    'shortDescription' => 'Sample generated class',
-    'longDescription'  => 'This is a class generated with Laminas\Code\Generator.',
-    'tags'             => [
-        [
-            'name'        => 'version',
-            'description' => '$Rev:$',
-        ],
-        [
-            'name'        => 'license',
-            'description' => 'New BSD',
-        ],
-    ],
-]);
-$foo->setName('Foo')
-    ->setDocblock($docblock);
-echo $foo->generate();
+echo (new ClassGenerator())
+    ->setName('Foo')
+    ->setDocblock(
+        (new DocBlockGenerator())
+            ->setShortDescription('Sample generated class')
+            ->setLongDescription('This is a class generated with Laminas\Code\Generator.')
+            ->setTags([
+                new GenericTag('version', '$Rev:$'),
+                new GenericTag('license', 'New BSD'),
+            ])
+    )
+    ->generate();
 ```
 
 The above code will result in the following:
@@ -55,31 +50,25 @@ use Laminas\Code\Generator\ClassGenerator;
 use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\PropertyGenerator;
 
-$foo      = new ClassGenerator();
-$docblock = DocBlockGenerator::fromArray([
-    'shortDescription' => 'Sample generated class',
-    'longDescription'  => 'This is a class generated with Laminas\Code\Generator.',
-    'tags'             => [
-        [
-            'name'        => 'version',
-            'description' => '$Rev:$',
-        ],
-        [
-            'name'        => 'license',
-            'description' => 'New BSD',
-        ],
-    ],
-]);
-$foo->setName('Foo')
-    ->setDocblock($docblock)
+echo (new ClassGenerator())
+    ->setName('Foo')
+    ->setDocblock(
+        (new DocBlockGenerator())
+            ->setShortDescription('Sample generated class')
+            ->setLongDescription('This is a class generated with Laminas\Code\Generator.')
+            ->setTags([
+                new GenericTag('version', '$Rev:$'),
+                new GenericTag('license', 'New BSD'),
+            ])
+    )
     ->addProperties([
-         ['bar', 'baz', PropertyGenerator::FLAG_PROTECTED],
-         ['baz', 'bat', PropertyGenerator::FLAG_PUBLIC]
+        new PropertyGenerator('bar', 'baz', PropertyGenerator::FLAG_PROTECTED),
+        new PropertyGenerator('baz', 'bat', PropertyGenerator::FLAG_PUBLIC),
    ])
    ->addConstants([
-         ['bat',  'foobarbazbat']
+        new PropertyGenerator('bat', 'foobarbazbat', PropertyGenerator::FLAG_CONSTANT)
     ]);
-echo $foo->generate();
+    ->generate();
 ```
 
 The above results in the following class definition:
@@ -117,55 +106,49 @@ use Laminas\Code\Generator\ClassGenerator;
 use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\DocBlock\Tag;
 use Laminas\Code\Generator\MethodGenerator;
+use Laminas\Code\Generator\ParameterGenerator;
 use Laminas\Code\Generator\PropertyGenerator;
 
-$foo      = new ClassGenerator();
-$docblock = DocBlockGenerator::fromArray([
-    'shortDescription' => 'Sample generated class',
-    'longDescription'  => 'This is a class generated with Laminas\Code\Generator.',
-    'tags'             => [
-        [
-            'name'        => 'version',
-            'description' => '$Rev:$',
-        ],
-        [
-            'name'        => 'license',
-            'description' => 'New BSD',
-        ],
-    ],
-]);
-$foo->setName('Foo')
-    ->setDocblock($docblock)
+echo (new ClassGenerator())
+    ->setName('Foo')
+    ->setDocblock(
+        (new DocBlockGenerator())
+            ->setShortDescription('Sample generated class')
+            ->setLongDescription('This is a class generated with Laminas\Code\Generator.')
+            ->setTags([
+                new GenericTag('version', '$Rev:$'),
+                new GenericTag('license', 'New BSD'),
+            ])
+    )
     ->addProperties([
-        ['bar',  'baz',          PropertyGenerator::FLAG_PROTECTED],
-        ['baz',  'bat',          PropertyGenerator::FLAG_PUBLIC]
+        new PropertyGenerator('bar', 'baz', PropertyGenerator::FLAG_PROTECTED),
+        new PropertyGenerator('baz', 'bat', PropertyGenerator::FLAG_PUBLIC),
     ])
     ->addConstants([
-        ['bat',  'foobarbazbat', PropertyGenerator::FLAG_CONSTANT]
-    ])
+        new PropertyGenerator('bat', 'foobarbazbat', PropertyGenerator::FLAG_CONSTANT)
+    ]);
     ->addMethods([
-        // Method passed as array
-        MethodGenerator::fromArray([
-            'name'       => 'setBar',
-            'parameters' => ['bar'],
-            'body'       => '$this->bar = $bar;' . "\n" . 'return $this;',
-            'docblock'   => DocBlockGenerator::fromArray([
-                'shortDescription' => 'Set the bar property',
-                'longDescription'  => null,
-                'tags'             => [
-                     new Tag\ParamTag(
-                        'bar', 
-                        [
-                            'string',
-                            'array'
-                        ],
-                        'parameter description'
-                    ),
-                    new Tag\ReturnTag([
-                        'datatype'  => 'string',
-                    ]),
-                ],
-            ]),
+        // Method built programmatically
+        (new MethodGenerator())
+            ->setName('setBar')
+            ->setParameters([
+                new ParameterGenerator('bar')
+            ])
+            ->setBody('$this->bar = $bar;' . "\n" . 'return $this;')
+            ->setDocBlock(
+                (new DocBlockGenerator())
+                    ->setShortDescription('Set the bar property')
+                    ->setTags([
+                        new Tag\ParamTag(
+                            'bar', 
+                            ['string', 'array'],
+                            'parameter description'
+                        ),
+                        new Tag\ReturnTag([
+                            'datatype'  => 'string',
+                        ]),
+                    ])
+            )
         ]),
         // Method passed as concrete instance
         new MethodGenerator(
@@ -173,19 +156,15 @@ $foo->setName('Foo')
             [],
             MethodGenerator::FLAG_PUBLIC,
             'return $this->bar;',
-            DocBlockGenerator::fromArray([
-                'shortDescription' => 'Retrieve the bar property',
-                'longDescription'  => null,
-                'tags'             => [
-                    new Tag\ReturnTag([
-                        'datatype'  => 'string|null',
-                    ]),
-                ],
+            (new DocBlockGenerator())
+                ->setShortDescription('Retrieve the bar property'),
+                ->setTags([
+                    new Tag\ReturnTag(['string|null']),
+                ])
             ])
         ),
     ]);
-
-echo $foo->generate();
+    ->generate();
 ```
 
 The above generates the following output:
@@ -244,21 +223,18 @@ previous example.
 ```php
 use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\DocBlock\Tag\GenericTag;
 
-$file = FileGenerator::fromArray([
-    'classes'  => [$foo],
-    'docblock' => DocBlockGenerator::fromArray([
-        'shortDescription' => 'Foo class file',
-        'longDescription'   => null,
-        'tags'             => [
-            [
-                'name'        => 'license',
-                'description' => 'New BSD',
-            ],
-        ],
-    ]),
-    'body'     => 'define(\'APPLICATION_ENV\', \'testing\');',
-]);
+$file = (new FileGenerator)
+    ->setClasses([$foo])
+    ->setDocBlock(
+        (new DocBlockGenerator())
+            ->setShortDescription('Foo class file')
+            ->setTag([
+                new GenericTag('license', 'New BSD')
+            ])
+    )
+    ->setBody('define(\'APPLICATION_ENV\', \'testing\');');
 ```
 
 Calling `generate()` will generate the code -- but not write it to a file. You will need to capture
@@ -346,19 +322,12 @@ $generator->addMethod(
     ['baz'],
     MethodGenerator::FLAG_PUBLIC,
     '$this->baz = $baz;' . "\n" . 'return $this;',
-    DocBlockGenerator::fromArray([
-        'shortDescription' => 'Set the baz property',
-        'longDescription'  => null,
-        'tags'             => [
-            new Tag\ParamTag([
-                'paramName' => 'baz',
-                'datatype'  => 'string'
-            ]),
-            new Tag\ReturnTag([
-                'datatype'  => 'string',
-            ]),
-        ],
-    ])
+    (new DocBlockGenerator())
+        ->setShortDescription('Set the baz property')
+        ->setTags([
+            new Tag\ParamTag('baz', ['string']),
+            new Tag\ReturnTag('string'),
+        ])
 );
 $code = $generator->generate();
 ```

--- a/docs/book/generator/reference.md
+++ b/docs/book/generator/reference.md
@@ -264,7 +264,6 @@ The *API* of the class is as follows:
 ```php
 class Laminas\Code\Generator\FileGenerator extends Laminas\Code\Generator\AbstractGenerator
 {
-    public static function fromArray(array $values)
     public function setDocblock(Laminas\Code\Generator\DocBlockGenerator $docblock)
     public function getDocblock()
     public function setRequiredFiles($requiredFiles)

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.24.0@06dd975cb55d36af80f242561738f16c5f58264f">
+<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
   <file src="src/DeclareStatement.php">
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$directive</code>
@@ -44,6 +44,9 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Generator/ClassGenerator.php">
+    <DeprecatedMethod occurrences="1">
+      <code>DocBlockGenerator::fromArray($value)</code>
+    </DeprecatedMethod>
     <DocblockTypeContradiction occurrences="3">
       <code>! is_string($name)</code>
       <code>is_string($name)</code>
@@ -296,6 +299,11 @@
     </UndefinedMethod>
   </file>
   <file src="src/Generator/FileGenerator.php">
+    <DeprecatedMethod occurrences="3">
+      <code>ClassGenerator::fromArray($class)</code>
+      <code>ClassGenerator::fromArray($value)</code>
+      <code>DeclareStatement::fromArray([$directive =&gt; $value])</code>
+    </DeprecatedMethod>
     <InvalidArgument occurrences="1">
       <code>$docBlock</code>
     </InvalidArgument>
@@ -342,6 +350,9 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/Generator/InterfaceGenerator.php">
+    <DeprecatedMethod occurrences="1">
+      <code>DocBlockGenerator::fromArray($value)</code>
+    </DeprecatedMethod>
     <MixedArgument occurrences="7">
       <code>$array['name']</code>
       <code>$value</code>
@@ -367,6 +378,10 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/Generator/MethodGenerator.php">
+    <DeprecatedMethod occurrences="2">
+      <code>DocBlockGenerator::fromArray($value)</code>
+      <code>ParameterGenerator::fromArray($parameter)</code>
+    </DeprecatedMethod>
     <MixedArgument occurrences="13">
       <code>$array['name']</code>
       <code>$parameterOutput</code>
@@ -440,6 +455,9 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/Generator/PropertyGenerator.php">
+    <DeprecatedMethod occurrences="1">
+      <code>DocBlockGenerator::fromArray($value)</code>
+    </DeprecatedMethod>
     <MixedArgument occurrences="9">
       <code>$array['name']</code>
       <code>$value</code>
@@ -469,6 +487,9 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/Generator/TraitGenerator.php">
+    <DeprecatedMethod occurrences="1">
+      <code>DocBlockGenerator::fromArray($value)</code>
+    </DeprecatedMethod>
     <MixedArgument occurrences="6">
       <code>$array['name']</code>
       <code>$value</code>
@@ -562,12 +583,11 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedOperand occurrences="5">
+    <MixedOperand occurrences="4">
       <code>$alias['alias']</code>
       <code>$insteadofTrait</code>
       <code>$method['method']</code>
       <code>$method['traitName']</code>
-      <code>current(Reflection::getModifierNames($alias['visibility']))</code>
     </MixedOperand>
     <TooFewArguments occurrences="1">
       <code>addTraitOverride</code>
@@ -1127,6 +1147,7 @@
       <code>'ParentClass'</code>
       <code>['Class1', 'Class2']</code>
     </ArgumentTypeCoercion>
+    <DeprecatedMethod occurrences="5"/>
     <InvalidArgument occurrences="5">
       <code>$resource</code>
       <code>ExceptionInterface::class</code>
@@ -1358,7 +1379,7 @@
     </InternalMethod>
   </file>
   <file src="test/Generator/DocBlockGeneratorTest.php">
-    <DeprecatedMethod occurrences="2">
+    <DeprecatedMethod occurrences="3">
       <code>setDatatype</code>
       <code>setDatatype</code>
     </DeprecatedMethod>
@@ -1381,6 +1402,7 @@
     </MissingReturnType>
   </file>
   <file src="test/Generator/FileGeneratorTest.php">
+    <DeprecatedMethod occurrences="9"/>
     <MissingReturnType occurrences="16">
       <code>testClassNotFoundException</code>
       <code>testConstruction</code>
@@ -1404,6 +1426,7 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>['Class1', 'Class2']</code>
     </ArgumentTypeCoercion>
+    <DeprecatedMethod occurrences="3"/>
     <MissingReturnType occurrences="17">
       <code>testAbstractAccessorsReturnsFalse</code>
       <code>testClassNotAnInterfaceException</code>
@@ -1435,6 +1458,11 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$className</code>
     </ArgumentTypeCoercion>
+    <DeprecatedMethod occurrences="6">
+      <code>ParameterGenerator::fromArray(['name' =&gt; 'bar', 'type' =&gt; 'array'])</code>
+      <code>ParameterGenerator::fromArray(['name' =&gt; 'baz', 'type' =&gt; stdClass::class, 'position' =&gt; 1])</code>
+      <code>ParameterGenerator::fromArray(['name' =&gt; 'baz', 'type' =&gt; stdClass::class])</code>
+    </DeprecatedMethod>
     <InvalidArgument occurrences="1">
       <code>new stdClass()</code>
     </InvalidArgument>
@@ -1471,6 +1499,7 @@
       <code>'LaminasTest_Code_NsTest_BarClass'</code>
       <code>'Namespaced\TypeHint\Bar'</code>
     </ArgumentTypeCoercion>
+    <DeprecatedMethod occurrences="1"/>
     <InvalidReturnStatement occurrences="1"/>
     <InvalidReturnType occurrences="1">
       <code>string[][]</code>
@@ -1507,6 +1536,7 @@
     </PossiblyNullArgument>
   </file>
   <file src="test/Generator/PropertyGeneratorTest.php">
+    <DeprecatedMethod occurrences="3"/>
     <InvalidArgument occurrences="1">
       <code>new stdClass()</code>
     </InvalidArgument>
@@ -1639,6 +1669,7 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>'LaminasTest_Code_NsTest_BarClass'</code>
     </ArgumentTypeCoercion>
+    <DeprecatedMethod occurrences="6"/>
     <InvalidArgument occurrences="1">
       <code>ExceptionInterface::class</code>
     </InvalidArgument>

--- a/src/DeclareStatement.php
+++ b/src/DeclareStatement.php
@@ -66,6 +66,10 @@ class DeclareStatement
         return new self(self::ENCODING, $value);
     }
 
+    /**
+     * @deprecated this API is deprecated, and will be removed in the next major release. Please
+     *             use the other constructors of this class instead.
+     */
     public static function fromArray(array $config): self
     {
         $directive = key($config);

--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -163,6 +163,9 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
     /**
      * Generate from array
      *
+     * @deprecated this API is deprecated, and will be removed in the next major release. Please
+     *             use the other constructors of this class instead.
+     *
      * @configkey name           string        [required] Class Name
      * @configkey filegenerator  FileGenerator File generator that holds this class
      * @configkey namespacename  string        The namespace for this class
@@ -175,9 +178,6 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return static
-     *
-     * @deprecated this API is deprecated, and will be removed in the next major release. Please
-     *             use the other constructors of this class instead.
      */
     public static function fromArray(array $array)
     {

--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -175,6 +175,9 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return static
+     *
+     * @deprecated this API is deprecated, and will be removed in the next major release. Please
+     *             use the other constructors of this class instead.
      */
     public static function fromArray(array $array)
     {

--- a/src/Generator/DocBlockGenerator.php
+++ b/src/Generator/DocBlockGenerator.php
@@ -54,15 +54,15 @@ class DocBlockGenerator extends AbstractGenerator
     /**
      * Generate from array
      *
+     * @deprecated this API is deprecated, and will be removed in the next major release. Please
+     *             use the other constructors of this class instead.
+     *
      * @configkey shortdescription string The short description for this doc block
      * @configkey longdescription  string The long description for this doc block
      * @configkey tags             array
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return DocBlockGenerator
-     *
-     * @deprecated this API is deprecated, and will be removed in the next major release. Please
-     *             use the other constructors of this class instead.
      */
     public static function fromArray(array $array)
     {

--- a/src/Generator/DocBlockGenerator.php
+++ b/src/Generator/DocBlockGenerator.php
@@ -60,6 +60,9 @@ class DocBlockGenerator extends AbstractGenerator
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return DocBlockGenerator
+     *
+     * @deprecated this API is deprecated, and will be removed in the next major release. Please
+     *             use the other constructors of this class instead.
      */
     public static function fromArray(array $array)
     {

--- a/src/Generator/FileGenerator.php
+++ b/src/Generator/FileGenerator.php
@@ -80,6 +80,9 @@ class FileGenerator extends AbstractGenerator
     /**
      * @param  array $values
      * @return FileGenerator
+     *
+     * @deprecated this API is deprecated, and will be removed in the next major release. Please
+     *             use the other constructors of this class instead.
      */
     public static function fromArray(array $values)
     {

--- a/src/Generator/FileGenerator.php
+++ b/src/Generator/FileGenerator.php
@@ -78,11 +78,11 @@ class FileGenerator extends AbstractGenerator
     }
 
     /**
-     * @param  array $values
-     * @return FileGenerator
-     *
      * @deprecated this API is deprecated, and will be removed in the next major release. Please
      *             use the other constructors of this class instead.
+     *
+     * @param  array $values
+     * @return FileGenerator
      */
     public static function fromArray(array $values)
     {

--- a/src/Generator/InterfaceGenerator.php
+++ b/src/Generator/InterfaceGenerator.php
@@ -67,6 +67,9 @@ class InterfaceGenerator extends ClassGenerator
     /**
      * Generate from array
      *
+     * @deprecated this API is deprecated, and will be removed in the next major release. Please
+     *             use the other constructors of this class instead.
+     *
      * @configkey name           string        [required] Class Name
      * @configkey filegenerator  FileGenerator File generator that holds this class
      * @configkey namespacename  string        The namespace for this class
@@ -76,9 +79,6 @@ class InterfaceGenerator extends ClassGenerator
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return static
-     *
-     * @deprecated this API is deprecated, and will be removed in the next major release. Please
-     *             use the other constructors of this class instead.
      */
     public static function fromArray(array $array)
     {

--- a/src/Generator/InterfaceGenerator.php
+++ b/src/Generator/InterfaceGenerator.php
@@ -76,6 +76,9 @@ class InterfaceGenerator extends ClassGenerator
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return static
+     *
+     * @deprecated this API is deprecated, and will be removed in the next major release. Please
+     *             use the other constructors of this class instead.
      */
     public static function fromArray(array $array)
     {

--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -118,6 +118,9 @@ class MethodGenerator extends AbstractMemberGenerator
     /**
      * Generate from array
      *
+     * @deprecated this API is deprecated, and will be removed in the next major release. Please
+     *             use the other constructors of this class instead.
+     *
      * @configkey name             string        [required] Class Name
      * @configkey docblock         string        The DocBlock information
      * @configkey flags            int           Flags, one of self::FLAG_ABSTRACT, self::FLAG_FINAL
@@ -132,9 +135,6 @@ class MethodGenerator extends AbstractMemberGenerator
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return MethodGenerator
-     *
-     * @deprecated this API is deprecated, and will be removed in the next major release. Please
-     *             use the other constructors of this class instead.
      */
     public static function fromArray(array $array)
     {

--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -132,6 +132,9 @@ class MethodGenerator extends AbstractMemberGenerator
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return MethodGenerator
+     *
+     * @deprecated this API is deprecated, and will be removed in the next major release. Please
+     *             use the other constructors of this class instead.
      */
     public static function fromArray(array $array)
     {

--- a/src/Generator/ParameterGenerator.php
+++ b/src/Generator/ParameterGenerator.php
@@ -59,6 +59,9 @@ class ParameterGenerator extends AbstractGenerator
     /**
      * Generate from array
      *
+     * @deprecated this API is deprecated, and will be removed in the next major release. Please
+     *             use the other constructors of this class instead.
+     *
      * @configkey name                  string                                          [required] Class Name
      * @configkey type                  string
      * @configkey defaultvalue          null|bool|string|int|float|array|ValueGenerator
@@ -71,9 +74,6 @@ class ParameterGenerator extends AbstractGenerator
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return ParameterGenerator
-     *
-     * @deprecated this API is deprecated, and will be removed in the next major release. Please
-     *             use the other constructors of this class instead.
      */
     public static function fromArray(array $array)
     {

--- a/src/Generator/ParameterGenerator.php
+++ b/src/Generator/ParameterGenerator.php
@@ -71,6 +71,9 @@ class ParameterGenerator extends AbstractGenerator
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return ParameterGenerator
+     *
+     * @deprecated this API is deprecated, and will be removed in the next major release. Please
+     *             use the other constructors of this class instead.
      */
     public static function fromArray(array $array)
     {

--- a/src/Generator/PropertyGenerator.php
+++ b/src/Generator/PropertyGenerator.php
@@ -100,6 +100,9 @@ class PropertyGenerator extends AbstractMemberGenerator
     /**
      * Generate from array
      *
+     * @deprecated this API is deprecated, and will be removed in the next major release. Please
+     *             use the other constructors of this class instead.
+     *
      * @configkey name               string   [required] Class Name
      * @configkey const              bool
      * @configkey defaultvalue       null|bool|string|int|float|array|ValueGenerator
@@ -114,9 +117,6 @@ class PropertyGenerator extends AbstractMemberGenerator
      * @param  array  $array
      * @return static
      * @throws Exception\InvalidArgumentException
-     *
-     * @deprecated this API is deprecated, and will be removed in the next major release. Please
-     *             use the other constructors of this class instead.
      */
     public static function fromArray(array $array)
     {

--- a/src/Generator/PropertyGenerator.php
+++ b/src/Generator/PropertyGenerator.php
@@ -114,6 +114,9 @@ class PropertyGenerator extends AbstractMemberGenerator
      * @param  array  $array
      * @return static
      * @throws Exception\InvalidArgumentException
+     *
+     * @deprecated this API is deprecated, and will be removed in the next major release. Please
+     *             use the other constructors of this class instead.
      */
     public static function fromArray(array $array)
     {

--- a/src/Generator/TraitGenerator.php
+++ b/src/Generator/TraitGenerator.php
@@ -69,6 +69,9 @@ class TraitGenerator extends ClassGenerator
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return static
+     *
+     * @deprecated this API is deprecated, and will be removed in the next major release. Please
+     *             use the other constructors of this class instead.
      */
     public static function fromArray(array $array)
     {

--- a/src/Generator/TraitGenerator.php
+++ b/src/Generator/TraitGenerator.php
@@ -60,6 +60,9 @@ class TraitGenerator extends ClassGenerator
     /**
      * Generate from array
      *
+     * @deprecated this API is deprecated, and will be removed in the next major release. Please
+     *             use the other constructors of this class instead.
+     *
      * @configkey name           string        [required] Class Name
      * @configkey filegenerator  FileGenerator File generator that holds this class
      * @configkey namespacename  string        The namespace for this class
@@ -69,9 +72,6 @@ class TraitGenerator extends ClassGenerator
      * @throws Exception\InvalidArgumentException
      * @param  array $array
      * @return static
-     *
-     * @deprecated this API is deprecated, and will be removed in the next major release. Please
-     *             use the other constructors of this class instead.
      */
     public static function fromArray(array $array)
     {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Deprecating all `::fromArray()` methods in in the package

These methods are brittle, badly documented, and very much
type-unsafe.

The `src/Generator` API is mostly composed of builder objects,
and `::fromArray()` is not necessary in it.

Please also do not use arbitrary user input, deserialized as
array, to generate code: it's a recipe for disaster.