### PR TITLE
Fix generating final classes from reflection

### DIFF
--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -85,6 +85,7 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
         }
 
         $cg->setAbstract($classReflection->isAbstract());
+        $cg->setFinal($classReflection->isFinal());
 
         // set the namespace
         if ($classReflection->inNamespace()) {

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -1395,7 +1395,7 @@ EOS;
         $expectedOutput = <<<EOS
 namespace LaminasTest\Code\Generator\TestAsset;
 
-class ClassWithPromotedParameter
+final class ClassWithPromotedParameter
 {
     public function __construct(private string \$promotedParameter)
     {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

When generating a class from reflection, the `final` flag was omitted. This PR fixes that (see tests).
