### PR TITLE
Use static data providers in preparation for PHPUnit 10

### DIFF
--- a/test/Generator/EnumGeneratorTest.php
+++ b/test/Generator/EnumGeneratorTest.php
@@ -44,7 +44,7 @@ final class EnumGeneratorTest extends TestCase
      *      1: non-empty-string
      * }>
      */
-    public function validOptionSpecifications(): iterable
+    public static function validOptionSpecifications(): iterable
     {
         yield 'pure enum without namespace' => [
             [
@@ -155,7 +155,7 @@ final class EnumGeneratorTest extends TestCase
      *      1: non-empty-string
      * }>
      */
-    public function validEnumSpecifications(): iterable
+    public static function validEnumSpecifications(): iterable
     {
         yield 'pure enum reflection' => [
             'TestNamespace\\Environment',

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -339,7 +339,7 @@ EOS;
      *     bool
      * }>
      */
-    public function returnsReferenceValues(): array
+    public static function returnsReferenceValues(): array
     {
         return [
             [true, true],
@@ -432,7 +432,7 @@ PHP;
      * @return string[][]
      * @psalm-return list<array{class-string, non-empty-string, non-empty-string}>
      */
-    public function returnTypeHintClasses()
+    public static function returnTypeHintClasses()
     {
         return [
             [ReturnTypeHintedClass::class, 'voidReturn', 'void'],
@@ -523,7 +523,7 @@ PHP;
     /**
      * @psalm-return non-empty-list<array{class-string, non-empty-string, non-empty-string, non-empty-string}>
      */
-    public function php80Methods(): array
+    public static function php80Methods(): array
     {
         return [
             [Php80Types::class, 'mixedType', 'mixed', 'mixed'],

--- a/test/Generator/ParameterGeneratorTest.php
+++ b/test/Generator/ParameterGeneratorTest.php
@@ -175,7 +175,7 @@ class ParameterGeneratorTest extends TestCase
      * @return string[][]
      * @psalm-return non-empty-list<array{non-empty-string, non-empty-string}>
      */
-    public function dataFromReflectionGenerate(): array
+    public static function dataFromReflectionGenerate(): array
     {
         return [
             ['name', '$param'],
@@ -305,7 +305,7 @@ class ParameterGeneratorTest extends TestCase
     /**
      * @return string[][]
      */
-    public function simpleHints()
+    public static function simpleHints()
     {
         return [
             ['callable', 'callable'],
@@ -347,7 +347,7 @@ class ParameterGeneratorTest extends TestCase
     /**
      * @return string[][]
      */
-    public function validClassName()
+    public static function validClassName()
     {
         return [
             ['stdClass'],
@@ -416,7 +416,7 @@ class ParameterGeneratorTest extends TestCase
     /**
      * @return string[][]
      */
-    public function reflectionHints()
+    public static function reflectionHints()
     {
         $parameters = [
             [InternalHintsClass::class, 'arrayParameter', 'foo', 'array'],
@@ -512,7 +512,7 @@ class ParameterGeneratorTest extends TestCase
     /**
      * @return string[][]
      */
-    public function variadicHints()
+    public static function variadicHints()
     {
         return [
             [VariadicParametersClass::class, 'firstVariadicParameter', 'foo', '... $foo'],
@@ -627,7 +627,7 @@ class ParameterGeneratorTest extends TestCase
     /**
      * @psalm-return non-empty-list<array{class-string, non-empty-string, positive-int|0, string, non-empty-string}>
      */
-    public function php80Methods(): array
+    public static function php80Methods(): array
     {
         return [
             [Php80Types::class, 'mixedType', 0, 'mixed', 'mixed $parameter'],

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -38,7 +38,7 @@ class PropertyGeneratorTest extends TestCase
     /**
      * @return bool[][]|string[][]|int[][]|null[][]
      */
-    public function dataSetTypeSetValueGenerate(): array
+    public static function dataSetTypeSetValueGenerate(): array
     {
         return [
             ['string', 'foo', "'foo';"],
@@ -122,7 +122,7 @@ EOS;
         self::assertSame($expectedSource, $targetSource);
     }
 
-    public function visibility(): Generator
+    public static function visibility(): Generator
     {
         yield 'public' => [PropertyGenerator::FLAG_PUBLIC, 'public'];
         yield 'protected' => [PropertyGenerator::FLAG_PROTECTED, 'protected'];

--- a/test/Generator/TypeGeneratorTest.php
+++ b/test/Generator/TypeGeneratorTest.php
@@ -73,7 +73,7 @@ class TypeGeneratorTest extends TestCase
      *            is that this library still supports generating code that is compatible with PHP 7,
      *            and therefore we cannot normalize nullable types to use `|null`, for now.
      */
-    public function validType()
+    public static function validType()
     {
         $valid = [
             ['\\foo', '\\foo'],
@@ -249,7 +249,7 @@ class TypeGeneratorTest extends TestCase
     /**
      * @return string[][]
      */
-    public function invalidType()
+    public static function invalidType()
     {
         $invalid = [
             [''],

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -60,7 +60,7 @@ class ValueGeneratorTest extends TestCase
      * @return object[][]
      * @psalm-return array<class-string, array{SplArrayObject|StdlibArrayObject}>
      */
-    public function constantsType(): array
+    public static function constantsType(): array
     {
         return [
             SplArrayObject::class    => [new SplArrayObject()],
@@ -84,7 +84,7 @@ class ValueGeneratorTest extends TestCase
      * @return array
      * @psalm-return non-empty-list<array{PropertyValueGenerator, non-empty-string}>
      */
-    public function validConstantTypes(): array
+    public static function validConstantTypes(): array
     {
         return [
             [
@@ -127,7 +127,7 @@ class ValueGeneratorTest extends TestCase
      * @param array $value
      * @return array
      */
-    protected function generateArrayData($longOutput, array $value)
+    protected static function generateArrayData($longOutput, array $value)
     {
         $shortOutput = str_replace(
             ['array(', ')'],
@@ -164,7 +164,7 @@ class ValueGeneratorTest extends TestCase
      *
      * @return array
      */
-    public function simpleArray()
+    public static function simpleArray()
     {
         $value = ['foo'];
 
@@ -174,7 +174,7 @@ array(
 )
 EOS;
 
-        return $this->generateArrayData($longOutput, $value);
+        return self::generateArrayData($longOutput, $value);
     }
 
     /**
@@ -182,7 +182,7 @@ EOS;
      *
      * @return array
      */
-    public function complexArray()
+    public static function complexArray()
     {
         $value = [
             5,
@@ -222,13 +222,13 @@ array(
 )
 EOS;
 
-        return $this->generateArrayData($longOutput, $value);
+        return self::generateArrayData($longOutput, $value);
     }
 
     /**
      * Data provider for testPropertyDefaultValueCanHandleComplexArrayWCustomIndentOfTypes test
      */
-    public function complexArrayWCustomIndent(): array
+    public static function complexArrayWCustomIndent(): array
     {
         $value = [
             '5bcf08a0a5d20' => [
@@ -302,7 +302,7 @@ array(
 )
 EOS;
 
-        return $this->generateArrayData($longOutput, $value);
+        return self::generateArrayData($longOutput, $value);
     }
 
     /**
@@ -310,7 +310,7 @@ EOS;
      *
      * @return array
      */
-    public function unsortedKeysArray()
+    public static function unsortedKeysArray()
     {
         $value = [
             1 => 'a',
@@ -330,7 +330,7 @@ array(
 )
 EOS;
 
-        return $this->generateArrayData($longOutput, $value);
+        return self::generateArrayData($longOutput, $value);
     }
 
     /**
@@ -467,7 +467,7 @@ EOS;
      *
      * @return string[][]
      */
-    public function getEscapedParameters()
+    public static function getEscapedParameters()
     {
         return [
             ['\\', '\\\\'],
@@ -476,7 +476,7 @@ EOS;
         ];
     }
 
-    public function invalidValue(): Generator
+    public static function invalidValue(): Generator
     {
         yield 'object' => [new DateTime(), DateTime::class];
         yield 'resource' => [fopen('php://input', 'r'), 'resource (stream)'];

--- a/test/Reflection/DocBlock/Tag/VarTagTest.php
+++ b/test/Reflection/DocBlock/Tag/VarTagTest.php
@@ -27,7 +27,7 @@ class VarTagTest extends TestCase
         $this->assertSame($expectedDescription, $tag->getDescription());
     }
 
-    public function varTagProvider(): array
+    public static function varTagProvider(): array
     {
         return [
             'only type'                            => [

--- a/test/Reflection/ParameterReflectionTest.php
+++ b/test/Reflection/ParameterReflectionTest.php
@@ -86,7 +86,7 @@ class ParameterReflectionTest extends TestCase
      * @return string[][]
      * @psalm-return non-empty-list<array{non-empty-string, non-empty-string}>
      */
-    public function paramType(): array
+    public static function paramType(): array
     {
         return [
             ['one', 'int'],
@@ -101,7 +101,7 @@ class ParameterReflectionTest extends TestCase
      * @return string[][]
      * @psalm-return non-empty-list<array{non-empty-string, non-empty-string}>
      */
-    public function paramTypeWithNotAllParamsDeclared(): array
+    public static function paramTypeWithNotAllParamsDeclared(): array
     {
         return [
             ['one', 'string'],
@@ -159,7 +159,7 @@ class ParameterReflectionTest extends TestCase
     /**
      * @return string[][]
      */
-    public function reflectionHints()
+    public static function reflectionHints()
     {
         return [
             [InternalHintsClass::class, 'arrayParameter', 'foo', 'array'],
@@ -214,7 +214,7 @@ class ParameterReflectionTest extends TestCase
     /**
      * @return string[][]
      */
-    public function docBlockHints()
+    public static function docBlockHints()
     {
         return [
             [DocBlockOnlyHintsClass::class, 'arrayParameter', 'foo', 'array'],

--- a/test/Reflection/ReflectionDocBlockTagTest.php
+++ b/test/Reflection/ReflectionDocBlockTagTest.php
@@ -161,7 +161,7 @@ class ReflectionDocBlockTagTest extends TestCase
         self::assertSame($expectedDescription, $varTag->getDescription());
     }
 
-    public function propertyVarDocProvider(): array
+    public static function propertyVarDocProvider(): array
     {
         return [
             'only type'                  => ['onlyType', ['string'], null, null],


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation |no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
Refactoring tests data providers to be static (to prepare for upcoming PHPUnit 10 changes: https://github.com/sebastianbergmann/phpunit/commit/9caafe2d49b33a21f87db248a8ad6ca7c7bdac09)