### PR TITLE
Make the return-type of `ClassReflection#getStartLine()` explicit

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -44,7 +44,8 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
     /**
      * {@inheritDoc}
      *
-     * @param bool $includeDocComment
+     * @param  bool $includeDocComment
+     * @return int|false
      */
     #[ReturnTypeWillChange]
     public function getStartLine($includeDocComment = false)


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

This was removed in #154 but this phpdoc is useful to some static analyzers, so that they can know what the future return-type is going to be.