### PR TITLE
Support generating properties, constants and parameter default values with ENUM references

### DIFF
--- a/src/Generator/FileGenerator.php
+++ b/src/Generator/FileGenerator.php
@@ -208,7 +208,7 @@ class FileGenerator extends AbstractGenerator
      *
      * @param  bool $withResolvedAs
      * @return array
-     * @psalm-return array<int, array{string, null|string, false|null|string}>
+     * @psalm-return array<int, array{string, null|string, null|string}>
      */
     public function getUses($withResolvedAs = false)
     {

--- a/src/Generator/FileGenerator.php
+++ b/src/Generator/FileGenerator.php
@@ -208,7 +208,7 @@ class FileGenerator extends AbstractGenerator
      *
      * @param  bool $withResolvedAs
      * @return array
-     * @psalm-return array<int, array{string, null|string, null|string}>
+     * @psalm-return array<int, array{string, null|string, false|null|string}>
      */
     public function getUses($withResolvedAs = false)
     {

--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -452,7 +452,7 @@ class ValueGenerator extends AbstractGenerator
                     throw new Exception\RuntimeException('Value is not an object.');
                 }
 
-                $output = sprintf('%s::%s', get_class($value), (string) $value->name);
+                $output = sprintf('%s::%s', $value::class, (string) $value->name);
                 break;
             case self::TYPE_OTHER:
             default:

--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -5,6 +5,7 @@ namespace Laminas\Code\Generator;
 use ArrayObject as SplArrayObject;
 use Laminas\Code\Exception\InvalidArgumentException;
 use Laminas\Stdlib\ArrayObject as StdlibArrayObject;
+use UnitEnum;
 
 use function addcslashes;
 use function array_keys;
@@ -44,6 +45,7 @@ class ValueGenerator extends AbstractGenerator
     public const TYPE_ARRAY_LONG  = 'array_long';
     public const TYPE_CONSTANT    = 'constant';
     public const TYPE_NULL        = 'null';
+    public const TYPE_ENUM        = 'enum';
     public const TYPE_OBJECT      = 'object';
     public const TYPE_OTHER       = 'other';
     /**#@-*/
@@ -286,6 +288,7 @@ class ValueGenerator extends AbstractGenerator
             self::TYPE_ARRAY_LONG,
             self::TYPE_CONSTANT,
             self::TYPE_NULL,
+            self::TYPE_ENUM,
             self::TYPE_OBJECT,
             self::TYPE_OTHER,
         ];
@@ -326,6 +329,10 @@ class ValueGenerator extends AbstractGenerator
             case 'NULL':
                 return self::TYPE_NULL;
             case 'object':
+                if ($value instanceof UnitEnum) {
+                    return self::TYPE_ENUM;
+                }
+                // enums are typed as objects, so this fall through is intentional
             case 'resource':
             case 'unknown type':
             default:
@@ -439,6 +446,13 @@ class ValueGenerator extends AbstractGenerator
                     $output .= self::LINE_FEED . str_repeat($this->indentation, $this->arrayDepth);
                 }
                 $output .= $endArray;
+                break;
+            case self::TYPE_ENUM:
+                if (! is_object($value)) {
+                    throw new Exception\RuntimeException('Value is not an object.');
+                }
+
+                $output = sprintf('%s::%s', get_class($value), (string) $value->name);
                 break;
             case self::TYPE_OTHER:
             default:

--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -24,7 +24,6 @@ use function max;
 use function sprintf;
 use function str_contains;
 use function str_repeat;
-use function strpos;
 
 class ValueGenerator extends AbstractGenerator
 {
@@ -452,7 +451,7 @@ class ValueGenerator extends AbstractGenerator
                     throw new Exception\RuntimeException('Value is not an object.');
                 }
 
-                $output = sprintf('%s::%s', $value::class, (string) $value->name);
+                $output = sprintf('\%s::%s', $value::class, (string) $value->name);
                 break;
             case self::TYPE_OTHER:
             default:

--- a/test/Generator/TestAsset/TestEnum.php
+++ b/test/Generator/TestAsset/TestEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace LaminasTest\Code\Generator\TestAsset;
+
+enum TestEnum
+{
+    case Test1;
+    case Test2;
+}

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -407,10 +407,14 @@ EOS;
 
         $valueGenerator1->initEnvironmentConstants();
         $valueGenerator2->initEnvironmentConstants();
+        /** @var TestEnum $value1 */
+        $value1 = $valueGenerator1->generate();
+        /** @var TestEnum $value2 */
+        $value2 = $valueGenerator2->generate();
 
-        self::assertNotEquals($valueGenerator1->generate(), $valueGenerator2->generate());
-        self::assertEquals(sprintf('%s::%s', TestEnum::class, 'Test1'), $valueGenerator1->generate());
-        self::assertEquals(sprintf('%s::%s', TestEnum::class, 'Test2'), $valueGenerator2->generate());
+        self::assertNotEquals($value1, $value2);
+        self::assertEquals(sprintf('%s::%s', TestEnum::class, 'Test1'), $value1);
+        self::assertEquals(sprintf('%s::%s', TestEnum::class, 'Test2'), $value2);
     }
 
     /**

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -390,7 +390,6 @@ EOS;
         self::assertNotEquals($valueGenerator1->generate(), $valueGenerator2->generate());
     }
 
-    /** @requires PHP >= 8.1 */
     public function testPropertyDefaultValueCanHandleEnums(): void
     {
         $valueGenerator1 = new ValueGenerator(
@@ -399,18 +398,10 @@ EOS;
             ValueGenerator::OUTPUT_MULTIPLE_LINE
         );
 
-        $valueGenerator2 = new ValueGenerator(
-            TestEnum::Test2,
-            ValueGenerator::TYPE_ENUM,
-            ValueGenerator::OUTPUT_MULTIPLE_LINE
-        );
+        $valueGenerator2 = new ValueGenerator(TestEnum::Test2);
 
-        $value1 = $valueGenerator1->generate();
-        $value2 = $valueGenerator2->generate();
-
-        self::assertNotEquals($value1, $value2);
-        self::assertEquals(sprintf('%s::%s', TestEnum::class, 'Test1'), $value1);
-        self::assertEquals(sprintf('%s::%s', TestEnum::class, 'Test2'), $value2);
+        self::assertSame('\LaminasTest\Code\Generator\TestAsset\TestEnum::Test1', $valueGenerator1->generate());
+        self::assertSame('\LaminasTest\Code\Generator\TestAsset\TestEnum::Test2', $valueGenerator2->generate());
     }
 
     /**

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -405,11 +405,7 @@ EOS;
             ValueGenerator::OUTPUT_MULTIPLE_LINE
         );
 
-        $valueGenerator1->initEnvironmentConstants();
-        $valueGenerator2->initEnvironmentConstants();
-        /** @var TestEnum $value1 */
         $value1 = $valueGenerator1->generate();
-        /** @var TestEnum $value2 */
         $value2 = $valueGenerator2->generate();
 
         self::assertNotEquals($value1, $value2);

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -12,9 +12,11 @@ use Laminas\Code\Generator\PropertyGenerator;
 use Laminas\Code\Generator\PropertyValueGenerator;
 use Laminas\Code\Generator\ValueGenerator;
 use Laminas\Stdlib\ArrayObject as StdlibArrayObject;
+use LaminasTest\Code\Generator\TestAsset\TestEnum;
 use PHPUnit\Framework\TestCase;
 
 use function fopen;
+use function sprintf;
 use function str_replace;
 
 /**
@@ -386,6 +388,29 @@ EOS;
         $valueGenerator2->initEnvironmentConstants();
 
         self::assertNotEquals($valueGenerator1->generate(), $valueGenerator2->generate());
+    }
+
+    /** @requires PHP >= 8.1 */
+    public function testPropertyDefaultValueCanHandleEnums(): void
+    {
+        $valueGenerator1 = new ValueGenerator(
+            TestEnum::Test1,
+            ValueGenerator::TYPE_AUTO,
+            ValueGenerator::OUTPUT_MULTIPLE_LINE
+        );
+
+        $valueGenerator2 = new ValueGenerator(
+            TestEnum::Test2,
+            ValueGenerator::TYPE_ENUM,
+            ValueGenerator::OUTPUT_MULTIPLE_LINE
+        );
+
+        $valueGenerator1->initEnvironmentConstants();
+        $valueGenerator2->initEnvironmentConstants();
+
+        self::assertNotEquals($valueGenerator1->generate(), $valueGenerator2->generate());
+        self::assertEquals(sprintf('%s::%s', TestEnum::class, 'Test1'), $valueGenerator1->generate());
+        self::assertEquals(sprintf('%s::%s', TestEnum::class, 'Test2'), $valueGenerator2->generate());
     }
 
     /**


### PR DESCRIPTION
This is a rebased and adjusted version of #143.

With this change, ENUMs can be used as default values in generated code (properties, parameters, etc).

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

Closes #143