### PR TITLE
Upgrade to PHPUnit 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.phpunit.result.cache
+/.phpunit.cache
 /clover.xml
 /coveralls-upload.json
 /docs/html/

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         "doctrine/annotations": "^2.0.0",
         "laminas/laminas-coding-standard": "^2.3.0",
         "laminas/laminas-stdlib": "^3.6.1",
-        "phpunit/phpunit": "^9.5.26",
-        "psalm/plugin-phpunit": "^0.18.0",
-        "vimeo/psalm": "^5.1.0"
+        "phpunit/phpunit": "^10.0.9",
+        "psalm/plugin-phpunit": "^0.18.4",
+        "vimeo/psalm": "^5.7.1"
     },
     "suggest": {
         "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a7b11831559c1e61f6e0c8b3b047082",
+    "content-hash": "8dc81efa9c15e6e8186ec0ac51c9b2da",
     "packages": [],
     "packages-dev": [
         {
@@ -653,76 +653,6 @@
             "time": "2022-12-19T18:17:20+00:00"
         },
         {
-            "name": "doctrine/instantiator",
-            "version": "1.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.22"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-03-03T08:28:38+00:00"
-        },
-        {
             "name": "doctrine/lexer",
             "version": "3.0.0",
             "source": {
@@ -902,16 +832,16 @@
         },
         {
             "name": "fidry/cpu-core-counter",
-            "version": "0.4.0",
+            "version": "0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "666cb04a02f2801f3b19955fc23c824f9018bf64"
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/666cb04a02f2801f3b19955fc23c824f9018bf64",
-                "reference": "666cb04a02f2801f3b19955fc23c824f9018bf64",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
                 "shasum": ""
             },
             "require": {
@@ -951,7 +881,7 @@
             ],
             "support": {
                 "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.4.0"
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.5.1"
             },
             "funding": [
                 {
@@ -959,7 +889,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-10T21:26:31+00:00"
+            "time": "2022-12-24T12:35:10+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",
@@ -1188,16 +1118,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.2",
+            "version": "v4.15.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc"
+                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
-                "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/570e980a201d8ed0236b0a62ddf2c9cbb2034039",
+                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039",
                 "shasum": ""
             },
             "require": {
@@ -1238,62 +1168,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.3"
             },
-            "time": "2022-11-12T15:38:23+00:00"
-        },
-        {
-            "name": "openlss/lib-array2xml",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nullivex/lib-array2xml.git",
-                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
-                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "LSS": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Bryan Tong",
-                    "email": "bryan@nullivex.com",
-                    "homepage": "https://www.nullivex.com"
-                },
-                {
-                    "name": "Tony Butler",
-                    "email": "spudz76@gmail.com",
-                    "homepage": "https://www.nullivex.com"
-                }
-            ],
-            "description": "Array2XML conversion library credit to lalit.org",
-            "homepage": "https://www.nullivex.com",
-            "keywords": [
-                "array",
-                "array conversion",
-                "xml",
-                "xml conversion"
-            ],
-            "support": {
-                "issues": "https://github.com/nullivex/lib-array2xml/issues",
-                "source": "https://github.com/nullivex/lib-array2xml/tree/master"
-            },
-            "time": "2019-03-29T20:06:56+00:00"
+            "time": "2023-01-16T22:05:37+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1617,16 +1494,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.21",
+            "version": "10.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "3f893e19712bb0c8bc86665d1562e9fd509c4ef0"
+                "reference": "bf4fbc9c13af7da12b3ea807574fb460f255daba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/3f893e19712bb0c8bc86665d1562e9fd509c4ef0",
-                "reference": "3f893e19712bb0c8bc86665d1562e9fd509c4ef0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/bf4fbc9c13af7da12b3ea807574fb460f255daba",
+                "reference": "bf4fbc9c13af7da12b3ea807574fb460f255daba",
                 "shasum": ""
             },
             "require": {
@@ -1634,18 +1511,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.14",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^3.0",
+                "sebastian/complexity": "^3.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/lines-of-code": "^2.0",
+                "sebastian/version": "^4.0",
                 "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcov": "*",
@@ -1654,7 +1531,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "10.0-dev"
                 }
             },
             "autoload": {
@@ -1682,7 +1559,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.21"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.0.0"
             },
             "funding": [
                 {
@@ -1690,32 +1567,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-14T13:26:54+00:00"
+            "time": "2023-02-03T07:14:34+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "fd9329ab3368f59fe1fe808a189c51086bd4b6bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/fd9329ab3368f59fe1fe808a189c51086bd4b6bd",
+                "reference": "fd9329ab3368f59fe1fe808a189c51086bd4b6bd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1742,7 +1619,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.1"
             },
             "funding": [
                 {
@@ -1750,28 +1627,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2023-02-10T16:53:14+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -1779,7 +1656,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1805,7 +1682,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
             },
             "funding": [
                 {
@@ -1813,32 +1690,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2023-02-03T06:56:09+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
+                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1864,7 +1741,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.0"
             },
             "funding": [
                 {
@@ -1872,32 +1749,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2023-02-03T06:56:46+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1923,7 +1800,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
             "funding": [
                 {
@@ -1931,24 +1808,23 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.27",
+            "version": "10.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38"
+                "reference": "b027e0e266b2e51bb74d5050ff5b1304c40ea209"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a2bc7ffdca99f92d959b3f2270529334030bba38",
-                "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b027e0e266b2e51bb74d5050ff5b1304c40ea209",
+                "reference": "b027e0e266b2e51bb74d5050ff5b1304c40ea209",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -1958,27 +1834,26 @@
                 "myclabs/deep-copy": "^1.10.1",
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.13",
-                "phpunit/php-file-iterator": "^3.0.5",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
-                "sebastian/version": "^3.0.2"
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.0",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-invoker": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "phpunit/php-timer": "^6.0",
+                "sebastian/cli-parser": "^2.0",
+                "sebastian/code-unit": "^2.0",
+                "sebastian/comparator": "^5.0",
+                "sebastian/diff": "^5.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/exporter": "^5.0",
+                "sebastian/global-state": "^6.0",
+                "sebastian/object-enumerator": "^5.0",
+                "sebastian/recursion-context": "^5.0",
+                "sebastian/type": "^4.0",
+                "sebastian/version": "^4.0"
             },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "*"
             },
             "bin": [
                 "phpunit"
@@ -1986,7 +1861,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.5-dev"
+                    "dev-main": "10.0-dev"
                 }
             },
             "autoload": {
@@ -2017,7 +1892,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.27"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.0.9"
             },
             "funding": [
                 {
@@ -2033,7 +1908,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-09T07:31:23+00:00"
+            "time": "2023-02-19T07:11:46+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -2249,28 +2124,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/efdc130dbbbb8ef0b545a994fd811725c5282cae",
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2293,7 +2168,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.0"
             },
             "funding": [
                 {
@@ -2301,32 +2176,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:08:49+00:00"
+            "time": "2023-02-03T06:58:15+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2349,7 +2224,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
             },
             "funding": [
                 {
@@ -2357,32 +2232,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2023-02-03T06:58:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2404,7 +2279,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2412,34 +2287,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/72f01e6586e0caf6af81297897bd112eb7e9627c",
+                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2478,7 +2355,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2486,33 +2363,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2023-02-03T07:07:16+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
+                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
-                "php": ">=7.3"
+                "nikic/php-parser": "^4.10",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2535,7 +2412,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2543,33 +2420,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-02-03T06:59:47+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "70dd1b20bc198da394ad542e988381b44e64e39f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/70dd1b20bc198da394ad542e988381b44e64e39f",
+                "reference": "70dd1b20bc198da394ad542e988381b44e64e39f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
+                "phpunit/phpunit": "^10.0",
                 "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2601,7 +2478,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2609,27 +2486,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-02-03T07:00:31+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.4",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
+                "reference": "b6f3694c6386c7959915a0037652e0c40f6f69cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b6f3694c6386c7959915a0037652e0c40f6f69cc",
+                "reference": "b6f3694c6386c7959915a0037652e0c40f6f69cc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -2637,7 +2514,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2656,7 +2533,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -2664,7 +2541,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.0"
             },
             "funding": [
                 {
@@ -2672,34 +2549,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-03T09:37:03+00:00"
+            "time": "2023-02-03T07:03:04+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
+                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2741,7 +2618,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2749,38 +2626,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2023-02-03T07:06:49+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.5",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+                "reference": "aab257c712de87b90194febd52e4d184551c2d44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/aab257c712de87b90194febd52e4d184551c2d44",
+                "reference": "aab257c712de87b90194febd52e4d184551c2d44",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2805,7 +2679,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.0"
             },
             "funding": [
                 {
@@ -2813,33 +2687,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-14T08:28:10+00:00"
+            "time": "2023-02-03T07:07:38+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/17c4d940ecafb3d15d2cf916f4108f664e28b130",
+                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
-                "php": ">=7.3"
+                "nikic/php-parser": "^4.10",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2862,7 +2736,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.0"
             },
             "funding": [
                 {
@@ -2870,34 +2744,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-02-03T07:08:02+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2919,7 +2793,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2927,32 +2801,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2974,7 +2848,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2982,32 +2856,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3034,10 +2908,10 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3045,87 +2919,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:17:30+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2023-02-03T07:05:40+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3148,7 +2967,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
             },
             "funding": [
                 {
@@ -3156,29 +2975,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-12T14:47:03+00:00"
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3201,7 +3020,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
             },
             "funding": [
                 {
@@ -3209,7 +3028,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -3273,6 +3092,69 @@
             "time": "2022-05-25T10:58:12+00:00"
         },
         {
+            "name": "spatie/array-to-xml",
+            "version": "3.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/array-to-xml.git",
+                "reference": "13f76acef5362d15c71ae1ac6350cc3df5e25e43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/13f76acef5362d15c71ae1ac6350cc3df5e25e43",
+                "reference": "13f76acef5362d15c71ae1ac6350cc3df5e25e43",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.2",
+                "pestphp/pest": "^1.21",
+                "spatie/pest-plugin-snapshots": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\ArrayToXml\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://freek.dev",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Convert an array to xml",
+            "homepage": "https://github.com/spatie/array-to-xml",
+            "keywords": [
+                "array",
+                "convert",
+                "xml"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/array-to-xml/tree/3.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-24T13:43:51+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.7.1",
             "source": {
@@ -3330,16 +3212,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.2.1",
+            "version": "v6.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "58f6cef5dc5f641b7bbdbf8b32b44cc926c35f3f"
+                "reference": "3e294254f2191762c1d137aed4b94e966965e985"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/58f6cef5dc5f641b7bbdbf8b32b44cc926c35f3f",
-                "reference": "58f6cef5dc5f641b7bbdbf8b32b44cc926c35f3f",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3e294254f2191762c1d137aed4b94e966965e985",
+                "reference": "3e294254f2191762c1d137aed4b94e966965e985",
                 "shasum": ""
             },
             "require": {
@@ -3406,7 +3288,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.2.1"
+                "source": "https://github.com/symfony/console/tree/v6.2.5"
             },
             "funding": [
                 {
@@ -3422,7 +3304,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-01T13:44:20+00:00"
+            "time": "2023-01-01T08:38:09+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3493,16 +3375,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.2.0",
+            "version": "v6.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "50b2523c874605cf3d4acf7a9e2b30b6a440a016"
+                "reference": "e59e8a4006afd7f5654786a83b4fcb8da98f4593"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/50b2523c874605cf3d4acf7a9e2b30b6a440a016",
-                "reference": "50b2523c874605cf3d4acf7a9e2b30b6a440a016",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e59e8a4006afd7f5654786a83b4fcb8da98f4593",
+                "reference": "e59e8a4006afd7f5654786a83b4fcb8da98f4593",
                 "shasum": ""
             },
             "require": {
@@ -3536,7 +3418,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.2.0"
+                "source": "https://github.com/symfony/filesystem/tree/v6.2.5"
             },
             "funding": [
                 {
@@ -3552,7 +3434,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-20T13:01:27+00:00"
+            "time": "2023-01-20T17:45:48+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3885,100 +3767,17 @@
             "time": "2022-11-03T14:55:06+00:00"
         },
         {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
             "name": "symfony/service-contracts",
-            "version": "v3.1.1",
+            "version": "v3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "925e713fe8fcacf6bc05e936edd8dd5441a21239"
+                "reference": "aac98028c69df04ee77eb69b96b86ee51fbf4b75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/925e713fe8fcacf6bc05e936edd8dd5441a21239",
-                "reference": "925e713fe8fcacf6bc05e936edd8dd5441a21239",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/aac98028c69df04ee77eb69b96b86ee51fbf4b75",
+                "reference": "aac98028c69df04ee77eb69b96b86ee51fbf4b75",
                 "shasum": ""
             },
             "require": {
@@ -3994,7 +3793,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.1-dev"
+                    "dev-main": "3.3-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4034,7 +3833,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.1.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.2.0"
             },
             "funding": [
                 {
@@ -4050,20 +3849,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-30T19:18:58+00:00"
+            "time": "2022-11-25T10:21:52+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.2.0",
+            "version": "v6.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "145702685e0d12f81d755c71127bfff7582fdd36"
+                "reference": "b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/145702685e0d12f81d755c71127bfff7582fdd36",
-                "reference": "145702685e0d12f81d755c71127bfff7582fdd36",
+                "url": "https://api.github.com/repos/symfony/string/zipball/b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0",
+                "reference": "b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0",
                 "shasum": ""
             },
             "require": {
@@ -4120,7 +3919,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.2.0"
+                "source": "https://github.com/symfony/string/tree/v6.2.5"
             },
             "funding": [
                 {
@@ -4136,7 +3935,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-30T17:13:47+00:00"
+            "time": "2023-01-01T08:38:09+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4190,16 +3989,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.2.0",
+            "version": "5.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "fb685a16df3050d4c18d8a4100fe83abe6458cba"
+                "reference": "8e0fd880141f236847ab49a06f94f788d41a4292"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/fb685a16df3050d4c18d8a4100fe83abe6458cba",
-                "reference": "fb685a16df3050d4c18d8a4100fe83abe6458cba",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/8e0fd880141f236847ab49a06f94f788d41a4292",
+                "reference": "8e0fd880141f236847ab49a06f94f788d41a4292",
                 "shasum": ""
             },
             "require": {
@@ -4218,28 +4017,27 @@
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.1",
                 "felixfbecker/language-server-protocol": "^1.5.2",
-                "fidry/cpu-core-counter": "^0.4.0",
+                "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
                 "nikic/php-parser": "^4.13",
-                "openlss/lib-array2xml": "^1.0",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
-                "sebastian/diff": "^4.0",
+                "sebastian/diff": "^4.0 || ^5.0",
+                "spatie/array-to-xml": "^2.17.0 || ^3.0",
                 "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
-                "symfony/filesystem": "^5.4 || ^6.0",
-                "symfony/polyfill-php80": "^1.25"
+                "symfony/filesystem": "^5.4 || ^6.0"
             },
             "provide": {
                 "psalm/psalm": "self.version"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.4",
-                "brianium/paratest": "^6.0",
+                "brianium/paratest": "^6.9",
                 "ext-curl": "*",
                 "mockery/mockery": "^1.5",
                 "nunomaduro/mock-final-classes": "^1.1",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/phpdoc-parser": "^1.6",
-                "phpunit/phpunit": "^9.5",
+                "phpunit/phpunit": "^9.6",
                 "psalm/plugin-mockery": "^1.1",
                 "psalm/plugin-phpunit": "^0.18",
                 "slevomat/coding-standard": "^8.4",
@@ -4285,13 +4083,14 @@
             "keywords": [
                 "code",
                 "inspection",
-                "php"
+                "php",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.2.0"
+                "source": "https://github.com/vimeo/psalm/tree/5.7.1"
             },
-            "time": "2022-12-12T08:18:56+00:00"
+            "time": "2023-02-20T00:48:41+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
-         cacheDirectory=".phpunit.cache"
 >
     <testsuites>
         <testsuite name="laminas-code Test Suite">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,24 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         convertDeprecationsToExceptions="true"
-         colors="true">
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+>
     <testsuites>
         <testsuite name="laminas-code Test Suite">
             <directory>./test</directory>
         </testsuite>
     </testsuites>
-
     <coverage>
         <include>
             <directory suffix=".php">./src</directory>
         </include>
     </coverage>
-
     <php>
         <!-- Enable this if you have installed Doctrine\Common on the
-             include_path or via Composer. -->
-        <env name="TESTS_LAMINAS_CODE_ANNOTATION_DOCTRINE_SUPPORT" value="false" />
+                 include_path or via Composer. -->
+        <env name="TESTS_LAMINAS_CODE_ANNOTATION_DOCTRINE_SUPPORT" value="false"/>
     </php>
 </phpunit>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,62 +1,77 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.1.0@4defa177c89397c5e14737a80fe4896584130674">
+<files psalm-version="5.7.1@8e0fd880141f236847ab49a06f94f788d41a4292">
   <file src="src/DeclareStatement.php">
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$directive</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>self</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>self::{$method}($value)</code>
     </MixedReturnStatement>
+    <PossiblyUnusedMethod>
+      <code>encoding</code>
+      <code>getValue</code>
+      <code>ticks</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Generator/AbstractGenerator.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($options) &amp;&amp; ! $options instanceof Traversable</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($options) && ! $options instanceof Traversable]]></code>
     </DocblockTypeContradiction>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$optionName</code>
       <code>$optionValue</code>
     </MixedAssignment>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$optionName</code>
     </MixedOperand>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $isSourceDirty</code>
       <code>(string) $indentation</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Generator/AbstractMemberGenerator.php">
-    <RedundantCastGivenDocblockType occurrences="1">
+    <PossiblyUnusedReturnValue>
+      <code>AbstractMemberGenerator</code>
+      <code>AbstractMemberGenerator</code>
+      <code>AbstractMemberGenerator</code>
+      <code>AbstractMemberGenerator</code>
+    </PossiblyUnusedReturnValue>
+    <RedundantCastGivenDocblockType>
       <code>(string) $name</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Generator/BodyGenerator.php">
-    <RedundantCastGivenDocblockType occurrences="1">
+    <PossiblyUnusedMethod>
+      <code>setContent</code>
+    </PossiblyUnusedMethod>
+    <RedundantCastGivenDocblockType>
       <code>(string) $content</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Generator/ClassGenerator.php">
-    <ArgumentTypeCoercion occurrences="2">
+    <ArgumentTypeCoercion>
       <code>$method</code>
       <code>$name</code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="1">
+    <DeprecatedMethod>
       <code>DocBlockGenerator::fromArray($value)</code>
     </DeprecatedMethod>
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction>
+      <code>empty($name) || ! is_string($name)</code>
       <code>is_string($name)</code>
       <code>is_string($name)</code>
     </DocblockTypeContradiction>
-    <InvalidNullableReturnType occurrences="1">
+    <InvalidNullableReturnType>
       <code>string</code>
     </InvalidNullableReturnType>
-    <MixedArgument occurrences="19">
-      <code>$array['name']</code>
+    <MixedArgument>
+      <code><![CDATA[$array['name']]]></code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
@@ -76,250 +91,281 @@
       <code>array_values($property)</code>
       <code>array_values($property)</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$name</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-    <MixedOperand occurrences="2">
+    <MixedOperand>
       <code>static::IMPLEMENTS_KEYWORD</code>
       <code>static::OBJECT_TYPE</code>
     </MixedOperand>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;traitUsageGenerator-&gt;getUseAlias($fqnClassName)</code>
+    <NullableReturnStatement>
+      <code><![CDATA[$this->traitUsageGenerator->getUseAlias($fqnClassName)]]></code>
     </NullableReturnStatement>
-    <PossiblyFalseArgument occurrences="1">
-      <code>strrpos($name, '\\')</code>
+    <PossiblyFalseArgument>
+      <code><![CDATA[strrpos($name, '\\')]]></code>
     </PossiblyFalseArgument>
-    <PossiblyFalseOperand occurrences="1">
-      <code>strrpos($name, '\\')</code>
+    <PossiblyFalseOperand>
+      <code><![CDATA[strrpos($name, '\\')]]></code>
     </PossiblyFalseOperand>
-    <PossiblyNullOperand occurrences="1">
+    <PossiblyNullOperand>
       <code>$namespaceAlias</code>
     </PossiblyNullOperand>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <PossiblyUnusedReturnValue>
+      <code>self</code>
+      <code>static</code>
+      <code>static</code>
+      <code>static</code>
+      <code>static</code>
+    </PossiblyUnusedReturnValue>
+    <RedundantConditionGivenDocblockType>
       <code>is_array($constant)</code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>! is_string($name)</code>
     </TypeDoesNotContainType>
-    <UnsafeInstantiation occurrences="2">
-      <code>new static($array['name'])</code>
-      <code>new static($classReflection-&gt;getName())</code>
+    <UnsafeInstantiation>
+      <code><![CDATA[new static($array['name'])]]></code>
+      <code><![CDATA[new static($classReflection->getName())]]></code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Generator/DocBlock/Tag.php">
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$tagManager-&gt;createTagFromReflection($reflectionTag)</code>
+    <LessSpecificReturnStatement>
+      <code><![CDATA[$tagManager->createTagFromReflection($reflectionTag)]]></code>
     </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>Tag</code>
     </MoreSpecificReturnType>
+    <PossiblyUnusedMethod>
+      <code>fromReflection</code>
+      <code>getDescription</code>
+      <code>setDescription</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Generator/DocBlock/Tag/AuthorTag.php">
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$tagManager-&gt;createTagFromReflection($reflectionTag)</code>
+    <LessSpecificReturnStatement>
+      <code><![CDATA[$tagManager->createTagFromReflection($reflectionTag)]]></code>
     </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>AuthorTag</code>
     </MoreSpecificReturnType>
+    <PossiblyUnusedMethod>
+      <code>fromReflection</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Generator/DocBlock/Tag/GenericTag.php">
-    <ImplementedReturnTypeMismatch occurrences="3">
+    <ImplementedReturnTypeMismatch>
       <code>$this</code>
       <code>$this</code>
       <code>string|null</code>
     </ImplementedReturnTypeMismatch>
-    <PossiblyNullOperand occurrences="1">
-      <code>$this-&gt;name</code>
+    <PossiblyNullOperand>
+      <code><![CDATA[$this->name]]></code>
     </PossiblyNullOperand>
   </file>
   <file src="src/Generator/DocBlock/Tag/LicenseTag.php">
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$tagManager-&gt;createTagFromReflection($reflectionTag)</code>
+    <LessSpecificReturnStatement>
+      <code><![CDATA[$tagManager->createTagFromReflection($reflectionTag)]]></code>
     </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>ReturnTag</code>
     </MoreSpecificReturnType>
+    <PossiblyUnusedMethod>
+      <code>fromReflection</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Generator/DocBlock/Tag/MethodTag.php">
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $isStatic</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Generator/DocBlock/Tag/ParamTag.php">
-    <LessSpecificReturnStatement occurrences="2">
-      <code>$tagManager-&gt;createTagFromReflection($reflectionTag)</code>
-      <code>$this-&gt;setTypes($datatype)</code>
+    <LessSpecificReturnStatement>
+      <code><![CDATA[$tagManager->createTagFromReflection($reflectionTag)]]></code>
+      <code><![CDATA[$this->setTypes($datatype)]]></code>
     </LessSpecificReturnStatement>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$types</code>
     </MixedArgumentTypeCoercion>
-    <MoreSpecificReturnType occurrences="2">
+    <MoreSpecificReturnType>
       <code>ParamTag</code>
       <code>ParamTag</code>
     </MoreSpecificReturnType>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PossiblyUnusedMethod>
+      <code>fromReflection</code>
+      <code>getDatatype</code>
+      <code>getParamName</code>
+      <code>setParamName</code>
+    </PossiblyUnusedMethod>
+    <PossiblyUnusedReturnValue>
+      <code>ParamTag</code>
+    </PossiblyUnusedReturnValue>
+    <PropertyNotSetInConstructor>
       <code>$variableName</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Generator/DocBlock/Tag/ReturnTag.php">
-    <LessSpecificReturnStatement occurrences="2">
-      <code>$tagManager-&gt;createTagFromReflection($reflectionTag)</code>
-      <code>$this-&gt;setTypes($datatype)</code>
+    <LessSpecificReturnStatement>
+      <code><![CDATA[$tagManager->createTagFromReflection($reflectionTag)]]></code>
+      <code><![CDATA[$this->setTypes($datatype)]]></code>
     </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="2">
+    <MoreSpecificReturnType>
       <code>ReturnTag</code>
       <code>ReturnTag</code>
     </MoreSpecificReturnType>
+    <PossiblyUnusedMethod>
+      <code>fromReflection</code>
+      <code>getDatatype</code>
+    </PossiblyUnusedMethod>
+    <PossiblyUnusedReturnValue>
+      <code>ReturnTag</code>
+    </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Generator/DocBlockGenerator.php">
-    <DeprecatedClass occurrences="1">
+    <DeprecatedClass>
       <code>new Tag()</code>
     </DeprecatedClass>
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$name</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-    <MixedReturnTypeCoercion occurrences="2">
-      <code>$this-&gt;tags</code>
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->tags]]></code>
       <code>TagInterface[]</code>
     </MixedReturnTypeCoercion>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $value</code>
     </RedundantCastGivenDocblockType>
-    <UnsafeInstantiation occurrences="2">
+    <UnsafeInstantiation>
       <code>new static()</code>
       <code>new static()</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Generator/EnumGenerator/Cases/BackedCases.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>$type === 'int' || $type === 'string'</code>
-      <code>$type === 'string'</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[$type === 'int' || $type === 'string']]></code>
+      <code><![CDATA[$type === 'string']]></code>
     </DocblockTypeContradiction>
-    <NoValue occurrences="1">
+    <NoValue>
       <code>$type</code>
     </NoValue>
   </file>
   <file src="src/Generator/EnumGenerator/Cases/CaseFactory.php">
-    <ArgumentTypeCoercion occurrences="3">
-      <code>$backingType-&gt;getName()</code>
-      <code>static fn(ReflectionEnumBackedCase $case): string =&gt; $case-&gt;getName()</code>
-      <code>static fn(ReflectionEnumBackedCase $case): string|int =&gt; $case-&gt;getBackingValue()</code>
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$backingType->getName()]]></code>
+      <code><![CDATA[static fn(ReflectionEnumBackedCase $case): string => $case->getName()]]></code>
+      <code><![CDATA[static fn(ReflectionEnumBackedCase $case): string|int => $case->getBackingValue()]]></code>
     </ArgumentTypeCoercion>
-    <LessSpecificReturnStatement occurrences="2">
-      <code>$case-&gt;getName()</code>
-      <code>$singleCase-&gt;getName()</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="2">
-      <code>non-empty-string</code>
-      <code>non-empty-string</code>
-    </MoreSpecificReturnType>
   </file>
   <file src="src/Generator/FileGenerator.php">
-    <DeprecatedMethod occurrences="3">
+    <DeprecatedMethod>
       <code>ClassGenerator::fromArray($class)</code>
       <code>ClassGenerator::fromArray($value)</code>
-      <code>DeclareStatement::fromArray([$directive =&gt; $value])</code>
+      <code><![CDATA[DeclareStatement::fromArray([$directive => $value])]]></code>
     </DeprecatedMethod>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$docBlock</code>
     </InvalidArgument>
-    <InvalidArrayOffset occurrences="1">
-      <code>[$directive =&gt; $value]</code>
+    <InvalidArrayOffset>
+      <code><![CDATA[[$directive => $value]]]></code>
     </InvalidArrayOffset>
-    <InvalidReturnStatement occurrences="1">
+    <LessSpecificReturnStatement>
       <code>$uses</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>array&lt;int, array{string, null|string, false|null|string}&gt;</code>
-    </InvalidReturnType>
-    <MissingClosureParamType occurrences="1">
+    </LessSpecificReturnStatement>
+    <MissingClosureParamType>
       <code>$value</code>
     </MissingClosureParamType>
-    <MixedArgument occurrences="5">
+    <MixedArgument>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="2">
+    <MixedArgumentTypeCoercion>
       <code>$name</code>
       <code>$name</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-    <PossiblyNullArgument occurrences="1">
+    <MoreSpecificReturnType>
+      <code><![CDATA[array<int, array{string, null|string, false|null|string}>]]></code>
+    </MoreSpecificReturnType>
+    <PossiblyNullArgument>
       <code>current($use)</code>
     </PossiblyNullArgument>
-    <PossiblyUndefinedArrayOffset occurrences="2">
+    <PossiblyUndefinedArrayOffset>
       <code>$alias</code>
       <code>$import</code>
+      <code>$uses[$useIndex][0]</code>
+      <code>$uses[$useIndex][1]</code>
     </PossiblyUndefinedArrayOffset>
-    <RedundantCastGivenDocblockType occurrences="3">
+    <PossiblyUnusedMethod>
+      <code>getFilename</code>
+      <code>setBody</code>
+      <code>setClasses</code>
+      <code>setDocBlock</code>
+    </PossiblyUnusedMethod>
+    <RedundantCastGivenDocblockType>
       <code>(string) $body</code>
       <code>(string) $filename</code>
       <code>(string) $namespace</code>
     </RedundantCastGivenDocblockType>
-    <UnsafeInstantiation occurrences="1">
+    <UnsafeInstantiation>
       <code>new static()</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Generator/InterfaceGenerator.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$name</code>
-    </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="1">
+    <DeprecatedMethod>
       <code>DocBlockGenerator::fromArray($value)</code>
     </DeprecatedMethod>
-    <InvalidClassConstantType occurrences="2">
+    <InvalidClassConstantType>
       <code>IMPLEMENTS_KEYWORD</code>
       <code>OBJECT_TYPE</code>
     </InvalidClassConstantType>
-    <MixedArgument occurrences="6">
-      <code>$array['name']</code>
+    <MixedArgument>
+      <code><![CDATA[$array['name']]]></code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$name</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <UnsafeInstantiation occurrences="2">
-      <code>new static($array['name'])</code>
-      <code>new static($classReflection-&gt;getName())</code>
+    <UnsafeInstantiation>
+      <code><![CDATA[new static($array['name'])]]></code>
+      <code><![CDATA[new static($classReflection->getName())]]></code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Generator/MethodGenerator.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$reflectionMethod-&gt;getReturnType()</code>
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$reflectionMethod->getReturnType()]]></code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="2">
+    <DeprecatedMethod>
       <code>DocBlockGenerator::fromArray($value)</code>
       <code>ParameterGenerator::fromArray($parameter)</code>
     </DeprecatedMethod>
-    <MethodSignatureMustProvideReturnType occurrences="1">
+    <MethodSignatureMustProvideReturnType>
       <code>__toString</code>
     </MethodSignatureMustProvideReturnType>
-    <MixedArgument occurrences="11">
-      <code>$array['name']</code>
+    <MixedArgument>
+      <code><![CDATA[$array['name']]]></code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
@@ -331,29 +377,29 @@
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$name</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-    <PossiblyFalseArgument occurrences="1">
-      <code>$reflectionMethod-&gt;getDocBlock()</code>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$reflectionMethod->getDocBlock()]]></code>
     </PossiblyFalseArgument>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $returnsReference</code>
     </RedundantCastGivenDocblockType>
-    <UnsafeInstantiation occurrences="2">
-      <code>new static($array['name'])</code>
+    <UnsafeInstantiation>
+      <code><![CDATA[new static($array['name'])]]></code>
       <code>new static()</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Generator/ParameterGenerator.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$reflectionParameter-&gt;getType()</code>
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$reflectionParameter->getType()]]></code>
     </ArgumentTypeCoercion>
-    <MixedArgument occurrences="8">
-      <code>$array['name']</code>
+    <MixedArgument>
+      <code><![CDATA[$array['name']]]></code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
@@ -362,31 +408,31 @@
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$name</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-    <RedundantCastGivenDocblockType occurrences="4">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $passedByReference</code>
       <code>(bool) $variadic</code>
       <code>(int) $position</code>
       <code>(string) $name</code>
     </RedundantCastGivenDocblockType>
-    <UnsafeInstantiation occurrences="1">
-      <code>new static($array['name'])</code>
+    <UnsafeInstantiation>
+      <code><![CDATA[new static($array['name'])]]></code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Generator/PropertyGenerator.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$reflectionProperty-&gt;getType()</code>
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$reflectionProperty->getType()]]></code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="1">
+    <DeprecatedMethod>
       <code>DocBlockGenerator::fromArray($value)</code>
     </DeprecatedMethod>
-    <MixedArgument occurrences="9">
-      <code>$array['name']</code>
+    <MixedArgument>
+      <code><![CDATA[$array['name']]]></code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
@@ -396,77 +442,80 @@
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$name</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$defaultValue</code>
     </MixedAssignment>
-    <UnsafeInstantiation occurrences="2">
-      <code>new static($array['name'])</code>
+    <PossiblyUnusedProperty>
+      <code>$isConst</code>
+    </PossiblyUnusedProperty>
+    <UnsafeInstantiation>
+      <code><![CDATA[new static($array['name'])]]></code>
       <code>new static()</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Generator/TraitGenerator.php">
-    <DeprecatedMethod occurrences="1">
+    <DeprecatedMethod>
       <code>DocBlockGenerator::fromArray($value)</code>
     </DeprecatedMethod>
-    <InvalidClassConstantType occurrences="1">
+    <InvalidClassConstantType>
       <code>OBJECT_TYPE</code>
     </InvalidClassConstantType>
-    <MixedArgument occurrences="6">
-      <code>$array['name']</code>
+    <MixedArgument>
+      <code><![CDATA[$array['name']]]></code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$name</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-    <PossiblyFalseArgument occurrences="1">
-      <code>$classReflection-&gt;getDocBlock()</code>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$classReflection->getDocBlock()]]></code>
     </PossiblyFalseArgument>
-    <UnsafeInstantiation occurrences="2">
-      <code>new static($array['name'])</code>
-      <code>new static($classReflection-&gt;getName())</code>
+    <UnsafeInstantiation>
+      <code><![CDATA[new static($array['name'])]]></code>
+      <code><![CDATA[new static($classReflection->getName())]]></code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Generator/TraitUsageGenerator.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_string($alias)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="6">
+    <MixedArgument>
       <code>$method</code>
-      <code>$this-&gt;traitOverrides[$method]</code>
-      <code>$this-&gt;traitOverrides[$traitAndMethod]</code>
+      <code><![CDATA[$this->traitOverrides[$method]]]></code>
+      <code><![CDATA[$this->traitOverrides[$traitAndMethod]]]></code>
       <code>$traitAndMethod</code>
       <code>$traitAndMethod</code>
       <code>$traitAndMethod</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$traits</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="1">
-      <code>$this-&gt;traitOverrides[$method][$key]</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$this->traitOverrides[$method][$key]]]></code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="1">
-      <code>$this-&gt;traitOverrides[$traitAndMethod][]</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$this->traitOverrides[$traitAndMethod][]]]></code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="4">
-      <code>$this-&gt;traitOverrides[$method][$key]</code>
-      <code>$this-&gt;traitOverrides[$traitAndMethod]</code>
-      <code>$this-&gt;traitOverrides[$traitAndMethod]</code>
-      <code>$this-&gt;traitOverrides[$traitAndMethod]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->traitOverrides[$method][$key]]]></code>
+      <code><![CDATA[$this->traitOverrides[$traitAndMethod]]]></code>
+      <code><![CDATA[$this->traitOverrides[$traitAndMethod]]]></code>
+      <code><![CDATA[$this->traitOverrides[$traitAndMethod]]]></code>
     </MixedArrayOffset>
-    <MixedArrayTypeCoercion occurrences="1">
-      <code>$this-&gt;traitOverrides[$traitAndMethod]</code>
+    <MixedArrayTypeCoercion>
+      <code><![CDATA[$this->traitOverrides[$traitAndMethod]]]></code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment>
       <code>$alias</code>
       <code>$insteadof</code>
       <code>$insteadofTrait</code>
@@ -475,22 +524,27 @@
       <code>$traitAndMethod</code>
       <code>$traitToRemove</code>
     </MixedAssignment>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$insteadofTrait</code>
     </MixedOperand>
-    <TooFewArguments occurrences="2">
+    <TooFewArguments>
       <code>addTraitOverride</code>
       <code>addTraitOverride</code>
     </TooFewArguments>
-    <TypeDoesNotContainType occurrences="1"/>
-    <UndefinedMethod occurrences="1">
+    <TypeDoesNotContainType>
+      <code><![CDATA[null !== $visibility
+            && $visibility !== ReflectionMethod::IS_PUBLIC
+            && $visibility !== ReflectionMethod::IS_PRIVATE
+            && $visibility !== ReflectionMethod::IS_PROTECTED]]></code>
+    </TypeDoesNotContainType>
+    <UndefinedMethod>
       <code>addAlias</code>
     </UndefinedMethod>
-    <UnusedForeachValue occurrences="2">
+    <UnusedForeachValue>
       <code>$value</code>
       <code>$value</code>
     </UnusedForeachValue>
-    <UnusedVariable occurrences="6">
+    <UnusedVariable>
       <code>$key</code>
       <code>$key</code>
       <code>$key</code>
@@ -499,264 +553,353 @@
       <code>$method</code>
     </UnusedVariable>
   </file>
+  <file src="src/Generator/TraitUsageInterface.php">
+    <PossiblyUnusedReturnValue>
+      <code>$this</code>
+      <code>$this</code>
+      <code>self</code>
+      <code>self</code>
+      <code>self</code>
+      <code>self</code>
+    </PossiblyUnusedReturnValue>
+  </file>
   <file src="src/Generator/TypeGenerator.php">
-    <ArgumentTypeCoercion occurrences="1"/>
-    <ImpureMethodCall occurrences="3">
-      <code>allowsNull</code>
-      <code>getTypes</code>
-      <code>getTypes</code>
-    </ImpureMethodCall>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$type</code>
     </InvalidArgument>
-    <RedundantCondition occurrences="2">
-      <code>$atomicType !== 'null'</code>
-      <code>$atomicType-&gt;type !== 'mixed' &amp;&amp; $atomicType !== 'null'</code>
+    <RedundantCondition>
+      <code><![CDATA[$atomicType !== 'null']]></code>
+      <code><![CDATA[$atomicType->type !== 'mixed' && $atomicType !== 'null']]></code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>$type instanceof ReflectionNamedType</code>
     </RedundantConditionGivenDocblockType>
   </file>
-  <file src="src/Generator/TypeGenerator/AtomicType.php">
-    <ImpureMethodCall occurrences="3">
-      <code>getName</code>
-      <code>getName</code>
-      <code>getParentClass</code>
-    </ImpureMethodCall>
-  </file>
   <file src="src/Generator/ValueGenerator.php">
-    <DeprecatedMethod occurrences="1">
+    <DeprecatedMethod>
       <code>getConstants</code>
     </DeprecatedMethod>
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction>
       <code>$constants instanceof SplArrayObject || $constants instanceof StdlibArrayObject</code>
       <code>$constants instanceof StdlibArrayObject</code>
     </DocblockTypeContradiction>
-    <MethodSignatureMustProvideReturnType occurrences="1">
+    <MethodSignatureMustProvideReturnType>
       <code>__toString</code>
     </MethodSignatureMustProvideReturnType>
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>initEnvironmentConstants</code>
     </MissingReturnType>
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$constant</code>
       <code>$n</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$constant</code>
       <code>$curValue</code>
       <code>$n</code>
       <code>$v</code>
-      <code>$value</code>
     </MixedAssignment>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$value</code>
     </MixedOperand>
-    <RedundantCastGivenDocblockType occurrences="3">
+    <PossiblyUnusedMethod>
+      <code>addConstant</code>
+      <code>deleteConstant</code>
+      <code>getArrayDepth</code>
+      <code>getOutputMode</code>
+    </PossiblyUnusedMethod>
+    <PossiblyUnusedProperty>
+      <code>$allowedTypes</code>
+    </PossiblyUnusedProperty>
+    <RedundantCastGivenDocblockType>
       <code>(int) $arrayDepth</code>
       <code>(string) $outputMode</code>
       <code>(string) $type</code>
     </RedundantCastGivenDocblockType>
-    <UnevaluatedCode occurrences="1">
-      <code>'float'</code>
+    <UnevaluatedCode>
+      <code><![CDATA['float']]></code>
     </UnevaluatedCode>
   </file>
   <file src="src/Generic/Prototype/PrototypeClassFactory.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$newPrototype</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>PrototypeInterface</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>setName</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>$newPrototype</code>
     </MixedReturnStatement>
-    <PossiblyInvalidClone occurrences="1">
-      <code>clone $this-&gt;genericPrototype</code>
+    <PossiblyInvalidClone>
+      <code><![CDATA[clone $this->genericPrototype]]></code>
     </PossiblyInvalidClone>
   </file>
   <file src="src/Reflection/ClassReflection.php">
-    <InvalidThrow occurrences="1">
+    <ArgumentTypeCoercion>
+      <code>$filter</code>
+      <code>$filter</code>
+    </ArgumentTypeCoercion>
+    <InvalidThrow>
       <code>Exception\ExceptionInterface</code>
     </InvalidThrow>
-    <MethodSignatureMustProvideReturnType occurrences="1">
+    <LessSpecificImplementedReturnType>
+      <code>int|false</code>
+    </LessSpecificImplementedReturnType>
+    <MethodSignatureMismatch>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+    </MethodSignatureMismatch>
+    <MethodSignatureMustProvideReturnType>
       <code>__toString</code>
     </MethodSignatureMustProvideReturnType>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MissingImmutableAnnotation>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+    </MissingImmutableAnnotation>
+    <MixedArgumentTypeCoercion>
       <code>$lines</code>
     </MixedArgumentTypeCoercion>
-    <PossiblyFalseArgument occurrences="1">
+    <PossiblyFalseArgument>
       <code>$startnum</code>
     </PossiblyFalseArgument>
-    <PossiblyFalseOperand occurrences="2">
+    <PossiblyFalseOperand>
       <code>$startnum</code>
-      <code>$this-&gt;getStartLine()</code>
+      <code><![CDATA[$this->getStartLine()]]></code>
     </PossiblyFalseOperand>
-    <PossiblyFalseReference occurrences="1">
+    <PossiblyFalseReference>
       <code>getStartLine</code>
     </PossiblyFalseReference>
   </file>
   <file src="src/Reflection/DocBlock/Tag/AuthorTag.php">
-    <MethodSignatureMustProvideReturnType occurrences="1">
+    <MethodSignatureMustProvideReturnType>
       <code>__toString</code>
     </MethodSignatureMustProvideReturnType>
   </file>
   <file src="src/Reflection/DocBlock/Tag/GenericTag.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->contentSplitCharacter]]></code>
+    </ArgumentTypeCoercion>
+    <ImplementedReturnTypeMismatch>
       <code>string|null</code>
     </ImplementedReturnTypeMismatch>
-    <MethodSignatureMustProvideReturnType occurrences="1">
+    <MethodSignatureMustProvideReturnType>
       <code>__toString</code>
     </MethodSignatureMustProvideReturnType>
-    <PossiblyNullOperand occurrences="1">
-      <code>$this-&gt;name</code>
+    <PossiblyNullOperand>
+      <code><![CDATA[$this->name]]></code>
     </PossiblyNullOperand>
+    <PossiblyUnusedMethod>
+      <code>getContent</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Reflection/DocBlock/Tag/LicenseTag.php">
-    <MethodSignatureMustProvideReturnType occurrences="1">
+    <MethodSignatureMustProvideReturnType>
       <code>__toString</code>
     </MethodSignatureMustProvideReturnType>
   </file>
   <file src="src/Reflection/DocBlock/Tag/MethodTag.php">
-    <MethodSignatureMustProvideReturnType occurrences="1">
+    <MethodSignatureMustProvideReturnType>
       <code>__toString</code>
     </MethodSignatureMustProvideReturnType>
   </file>
+  <file src="src/Reflection/DocBlock/Tag/ParamTag.php">
+    <PossiblyUnusedMethod>
+      <code>getDescription</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="src/Reflection/DocBlock/Tag/PropertyTag.php">
-    <MethodSignatureMustProvideReturnType occurrences="1">
+    <MethodSignatureMustProvideReturnType>
       <code>__toString</code>
     </MethodSignatureMustProvideReturnType>
   </file>
   <file src="src/Reflection/DocBlockReflection.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>! is_string($filter)</code>
     </DocblockTypeContradiction>
-    <MethodSignatureMustProvideReturnType occurrences="1">
+    <MethodSignatureMustProvideReturnType>
       <code>__toString</code>
     </MethodSignatureMustProvideReturnType>
-    <MixedArgument occurrences="3">
-      <code>$tag['name']</code>
-      <code>$tag['value']</code>
-      <code>$this-&gt;docComment</code>
+    <MixedArgument>
+      <code><![CDATA[$tag['name']]]></code>
+      <code><![CDATA[$tag['value']]]></code>
+      <code><![CDATA[$this->docComment]]></code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="2">
-      <code>$tag['name']</code>
-      <code>$tag['value']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$tag['name']]]></code>
+      <code><![CDATA[$tag['value']]]></code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment>
       <code>$returnTags[]</code>
       <code>$tag</code>
       <code>$tag</code>
       <code>$tag</code>
       <code>$tag</code>
       <code>$tag</code>
-      <code>$this-&gt;docComment</code>
-      <code>$this-&gt;endLine</code>
-      <code>$this-&gt;startLine</code>
+      <code><![CDATA[$this->docComment]]></code>
+      <code><![CDATA[$this->endLine]]></code>
+      <code><![CDATA[$this->startLine]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>DocBlockTagInterface|false</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="3">
+    <MixedMethodCall>
       <code>getName</code>
       <code>getName</code>
       <code>getName</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$tag</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>$tag</code>
     </MixedReturnStatement>
-    <MixedReturnTypeCoercion occurrences="3">
+    <MixedReturnTypeCoercion>
       <code>$returnTags</code>
-      <code>$this-&gt;tags</code>
+      <code><![CDATA[$this->tags]]></code>
       <code>DocBlockTagInterface[]</code>
     </MixedReturnTypeCoercion>
-    <PropertyNotSetInConstructor occurrences="3">
+    <PossiblyUnusedMethod>
+      <code>export</code>
+    </PossiblyUnusedMethod>
+    <PropertyNotSetInConstructor>
       <code>$endLine</code>
       <code>$reflector</code>
       <code>$startLine</code>
     </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>is_string($commentOrReflector)</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedInterfaceMethod occurrences="2">
+    <UndefinedInterfaceMethod>
       <code>getStartLine</code>
       <code>getStartLine</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="src/Reflection/Exception/BadMethodCallException.php">
+    <UnusedClass>
+      <code>BadMethodCallException</code>
+    </UnusedClass>
+  </file>
   <file src="src/Reflection/FunctionReflection.php">
-    <DeprecatedMethod occurrences="1">
+    <DeprecatedMethod>
       <code>detectType</code>
     </DeprecatedMethod>
-    <MethodSignatureMustProvideReturnType occurrences="1">
+    <FalsableReturnStatement>
+      <code>parent::getStartLine()</code>
+    </FalsableReturnStatement>
+    <InvalidFalsableReturnType>
+      <code>int</code>
+    </InvalidFalsableReturnType>
+    <InvalidOperand>
+      <code>$endLine</code>
+      <code>$endLine</code>
+    </InvalidOperand>
+    <MethodSignatureMismatch>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>public function __toString()</code>
+    </MethodSignatureMismatch>
+    <MethodSignatureMustProvideReturnType>
       <code>__toString</code>
     </MethodSignatureMustProvideReturnType>
-    <MixedArgument occurrences="2">
+    <MissingImmutableAnnotation>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>public function __toString()</code>
+    </MissingImmutableAnnotation>
+    <MixedArgument>
       <code>$returnTypes</code>
       <code>$returnTypes</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="2">
+    <MixedArgumentTypeCoercion>
       <code>$lines</code>
       <code>$lines</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="1">
+    <MixedArrayAccess>
       <code>$returnTypes[0]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$returnType</code>
       <code>$returnTypes</code>
     </MixedAssignment>
-    <MixedOperand occurrences="1">
-      <code>$prototype['return']</code>
+    <MixedOperand>
+      <code><![CDATA[$prototype['return']]]></code>
     </MixedOperand>
-    <PossiblyFalseOperand occurrences="2">
-      <code>strrpos($this-&gt;getName(), '\\')</code>
-      <code>strrpos($this-&gt;getName(), '\\')</code>
+    <PossiblyFalseOperand>
+      <code><![CDATA[strrpos($this->getName(), '\\')]]></code>
+      <code><![CDATA[strrpos($this->getName(), '\\')]]></code>
     </PossiblyFalseOperand>
-    <PossiblyFalseReference occurrences="2">
+    <PossiblyFalseReference>
       <code>getDescription</code>
       <code>getTypes</code>
     </PossiblyFalseReference>
-    <PossiblyInvalidOperand occurrences="6">
-      <code>$endLine</code>
-      <code>$endLine</code>
+    <PossiblyInvalidOperand>
       <code>$startLine</code>
       <code>$startLine</code>
       <code>$startLine</code>
       <code>$startLine</code>
     </PossiblyInvalidOperand>
-    <UndefinedInterfaceMethod occurrences="2">
+    <PossiblyUnusedMethod>
+      <code>getReturn</code>
+    </PossiblyUnusedMethod>
+    <UndefinedInterfaceMethod>
       <code>getDescription</code>
       <code>getTypes</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Reflection/MethodReflection.php">
-    <DeprecatedMethod occurrences="1">
+    <DeprecatedMethod>
       <code>detectType</code>
     </DeprecatedMethod>
-    <MethodSignatureMustProvideReturnType occurrences="1">
+    <FalsableReturnStatement>
+      <code>parent::getStartLine()</code>
+    </FalsableReturnStatement>
+    <InvalidFalsableReturnType>
+      <code>int</code>
+    </InvalidFalsableReturnType>
+    <MethodSignatureMismatch>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+    </MethodSignatureMismatch>
+    <MethodSignatureMustProvideReturnType>
       <code>__toString</code>
     </MethodSignatureMustProvideReturnType>
-    <MixedArgument occurrences="5">
+    <MissingImmutableAnnotation>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+    </MissingImmutableAnnotation>
+    <MixedArgument>
       <code>$haystack[$i][0]</code>
       <code>$haystack[$i][0]</code>
       <code>$haystack[$i][0]</code>
       <code>$returnTypes</code>
       <code>$returnTypes</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$lines</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="1">
+    <MixedArrayAccess>
       <code>$returnTypes[0]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment>
       <code>$returnType</code>
       <code>$returnTypes</code>
       <code>$tokenType</code>
@@ -765,72 +908,75 @@
       <code>$tokenValue</code>
       <code>$tokenValue</code>
     </MixedAssignment>
-    <MixedOperand occurrences="2">
-      <code>$prototype['return']</code>
+    <MixedOperand>
+      <code><![CDATA[$prototype['return']]]></code>
       <code>$tokenValue</code>
     </MixedOperand>
-    <PossiblyFalseReference occurrences="2">
+    <PossiblyFalseReference>
       <code>getStartLine</code>
       <code>getTypes</code>
     </PossiblyFalseReference>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>getTypes</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Reflection/ParameterReflection.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$function-&gt;getName()</code>
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$function->getName()]]></code>
     </ArgumentTypeCoercion>
-    <ImpureMethodCall occurrences="14">
-      <code>getDeclaringClass</code>
+    <ImpureMethodCall>
       <code>getDocBlock</code>
       <code>getDocBlock</code>
-      <code>getModifiers</code>
-      <code>getModifiers</code>
-      <code>getModifiers</code>
-      <code>getName</code>
-      <code>getName</code>
-      <code>getName</code>
-      <code>getName</code>
-      <code>getName</code>
-      <code>getName</code>
       <code>getProperty</code>
       <code>getTags</code>
     </ImpureMethodCall>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>string|null</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$type-&gt;getName()</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$type->getName()]]></code>
     </MixedReturnStatement>
-    <UndefinedMethod occurrences="3">
+    <PossiblyUnusedProperty>
+      <code>$isFromMethod</code>
+    </PossiblyUnusedProperty>
+    <UndefinedMethod>
       <code>getName</code>
       <code>getName</code>
       <code>isBuiltin</code>
     </UndefinedMethod>
   </file>
+  <file src="src/Reflection/PropertyReflection.php">
+    <MethodSignatureMismatch>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+    </MethodSignatureMismatch>
+    <MissingImmutableAnnotation>
+      <code>#[ReturnTypeWillChange]</code>
+      <code>#[ReturnTypeWillChange]</code>
+    </MissingImmutableAnnotation>
+  </file>
   <file src="src/Scanner/DocBlockScanner.php">
-    <InvalidArrayOffset occurrences="2">
-      <code>$this-&gt;tags[$tagIndex]</code>
-      <code>$this-&gt;tags[$tagIndex]</code>
+    <InvalidArrayOffset>
+      <code><![CDATA[$this->tags[$tagIndex]]]></code>
+      <code><![CDATA[$this->tags[$tagIndex]]]></code>
     </InvalidArrayOffset>
-    <MissingClosureParamType occurrences="3">
+    <MissingClosureParamType>
       <code>$length</code>
       <code>$positionsForward</code>
       <code>$type</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="9">
-      <code>function ($length) use (&amp;$currentWord, &amp;$tokens, &amp;$tokenIndex) {</code>
+    <MissingClosureReturnType>
+      <code><![CDATA[function ($length) use (&$currentWord, &$tokens, &$tokenIndex) {]]></code>
       <code>function ($positionsForward = 1) use (</code>
-      <code>function ($type) use (&amp;$tokenIndex, &amp;$tokens) {</code>
-      <code>function () use (&amp;$currentChar, &amp;$tokens, &amp;$tokenIndex) {</code>
-      <code>function () use (&amp;$currentLine, &amp;$MACRO_STREAM_ADVANCE_CHAR) {</code>
-      <code>function () use (&amp;$currentLine, &amp;$tokens, &amp;$tokenIndex) {</code>
-      <code>function () use (&amp;$currentWord, &amp;$MACRO_STREAM_ADVANCE_CHAR) {</code>
-      <code>function () use (&amp;$currentWord, &amp;$tokens, &amp;$tokenIndex) {</code>
-      <code>function () use (&amp;$tokenIndex, &amp;$tokens) {</code>
+      <code><![CDATA[function ($type) use (&$tokenIndex, &$tokens) {]]></code>
+      <code><![CDATA[function () use (&$currentChar, &$tokens, &$tokenIndex) {]]></code>
+      <code><![CDATA[function () use (&$currentLine, &$MACRO_STREAM_ADVANCE_CHAR) {]]></code>
+      <code><![CDATA[function () use (&$currentLine, &$tokens, &$tokenIndex) {]]></code>
+      <code><![CDATA[function () use (&$currentWord, &$MACRO_STREAM_ADVANCE_CHAR) {]]></code>
+      <code><![CDATA[function () use (&$currentWord, &$tokens, &$tokenIndex) {]]></code>
+      <code><![CDATA[function () use (&$tokenIndex, &$tokens) {]]></code>
     </MissingClosureReturnType>
-    <MixedArgument occurrences="9">
+    <MixedArgument>
       <code>$currentLine</code>
       <code>$currentWord</code>
       <code>$currentWord</code>
@@ -841,10 +987,10 @@
       <code>$streamIndex</code>
       <code>$tokens</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="19">
+    <MixedArrayAccess>
       <code>$stream[$streamIndex]</code>
-      <code>$this-&gt;tags[$tagIndex]['value']</code>
-      <code>$this-&gt;tags[$tagIndex]['value']</code>
+      <code><![CDATA[$this->tags[$tagIndex]['value']]]></code>
+      <code><![CDATA[$this->tags[$tagIndex]['value']]]></code>
       <code>$token[0]</code>
       <code>$token[1]</code>
       <code>$token[1]</code>
@@ -862,8 +1008,8 @@
       <code>$tokens[$tokenIndex][1]</code>
       <code>$tokens[$tokenIndex][1]</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="12">
-      <code>$this-&gt;tags[$tagIndex]['value']</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$this->tags[$tagIndex]['value']]]></code>
       <code>$tokens[$tokenIndex]</code>
       <code>$tokens[$tokenIndex]</code>
       <code>$tokens[$tokenIndex]</code>
@@ -876,7 +1022,7 @@
       <code>$tokens[$tokenIndex][1]</code>
       <code>$tokens[$tokenIndex][1]</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="13">
+    <MixedArrayOffset>
       <code>$stream[$streamIndex]</code>
       <code>$stream[$streamIndex]</code>
       <code>$tokens[$tokenIndex]</code>
@@ -891,7 +1037,7 @@
       <code>$tokens[$tokenIndex]</code>
       <code>$tokens[$tokenIndex]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="11">
+    <MixedAssignment>
       <code>$context</code>
       <code>$context</code>
       <code>$context</code>
@@ -904,17 +1050,17 @@
       <code>$tokenIndex</code>
       <code>$tokens[$tokenIndex][0]</code>
     </MixedAssignment>
-    <MixedFunctionCall occurrences="5">
+    <MixedFunctionCall>
       <code>$MACRO_STREAM_ADVANCE_CHAR()</code>
       <code>$MACRO_STREAM_ADVANCE_CHAR()</code>
       <code>$MACRO_STREAM_ADVANCE_CHAR()</code>
       <code>$MACRO_STREAM_ADVANCE_CHAR(strlen($currentLine))</code>
       <code>$MACRO_STREAM_ADVANCE_CHAR(strlen($currentWord))</code>
     </MixedFunctionCall>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="20">
+    <MixedOperand>
       <code>$CONTEXT_INSIDE_ASTERISK</code>
       <code>$CONTEXT_INSIDE_ASTERISK</code>
       <code>$CONTEXT_INSIDE_ASTERISK</code>
@@ -923,7 +1069,7 @@
       <code>$CONTEXT_INSIDE_DOCBLOCK</code>
       <code>$context</code>
       <code>$streamIndex</code>
-      <code>$this-&gt;tags[$tagIndex]['value']</code>
+      <code><![CDATA[$this->tags[$tagIndex]['value']]]></code>
       <code>$tokenIndex</code>
       <code>$token[1]</code>
       <code>$token[1]</code>
@@ -936,17 +1082,17 @@
       <code>~$CONTEXT_INSIDE_ASTERISK</code>
       <code>~$CONTEXT_INSIDE_DOCBLOCK</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>$tokens</code>
     </MixedReturnStatement>
-    <RedundantCondition occurrences="2">
+    <RedundantCondition>
       <code>$context === 0x00</code>
-      <code>$mode &lt;= 2</code>
+      <code><![CDATA[$mode <= 2]]></code>
     </RedundantCondition>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>$tagIndex !== null</code>
     </TypeDoesNotContainType>
-    <UnusedVariable occurrences="5">
+    <UnusedVariable>
       <code>$MACRO_TOKEN_APPEND_WORD_PARTIAL</code>
       <code>$context</code>
       <code>$context</code>
@@ -955,37 +1101,81 @@
     </UnusedVariable>
   </file>
   <file src="test/Generator/AbstractGeneratorTest.php">
-    <MissingReturnType occurrences="2">
+    <MissingReturnType>
       <code>testConstructor</code>
       <code>testSetOptionsThrowsExceptionOnInvalidArgument</code>
     </MissingReturnType>
   </file>
   <file src="test/Generator/AbstractMemberGeneratorTest.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>new stdClass()</code>
     </InvalidArgument>
-    <MissingReturnType occurrences="2">
+    <MissingReturnType>
       <code>testSetDocBlockThrowsExceptionWithInvalidType</code>
       <code>testSetFlagsWithArray</code>
     </MissingReturnType>
   </file>
   <file src="test/Generator/Cases/BackedCasesTest.php">
-    <InvalidArgument occurrences="1">
-      <code>'bool'</code>
+    <InvalidArgument>
+      <code><![CDATA['bool']]></code>
     </InvalidArgument>
   </file>
   <file src="test/Generator/ClassGeneratorTest.php">
-    <ArgumentTypeCoercion occurrences="7">
-      <code>''</code>
-      <code>'ExtendedClass'</code>
-      <code>'ExtendedClass'</code>
-      <code>'ExtendedClass'</code>
-      <code>'LaminasTest_Code_NsTest_BarClass'</code>
-      <code>'ParentClass'</code>
-      <code>['Class1', 'Class2']</code>
+    <ArgumentTypeCoercion>
+      <code><![CDATA['']]></code>
+      <code><![CDATA['ExtendedClass']]></code>
+      <code><![CDATA['ExtendedClass']]></code>
+      <code><![CDATA['ExtendedClass']]></code>
+      <code><![CDATA['LaminasTest_Code_NsTest_BarClass']]></code>
+      <code><![CDATA['ParentClass']]></code>
+      <code><![CDATA[['Class1', 'Class2']]]></code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="6"/>
-    <InvalidArgument occurrences="19">
+    <DeprecatedMethod>
+      <code><![CDATA[ClassGenerator::fromArray([
+            'name'                  => 'SampleClass',
+            'flags'                 => ClassGenerator::FLAG_ABSTRACT,
+            'extendedClass'         => 'ExtendedClassName',
+            'implementedInterfaces' => ['Iterator', 'Traversable'],
+            'properties'            => [
+                'foo',
+                ['name' => 'bar'],
+            ],
+            'methods'               => [
+                ['name' => 'baz'],
+            ],
+        ])]]></code>
+      <code><![CDATA[ClassGenerator::fromArray([
+            'name'       => 'ClassWithFinalConst',
+            'properties' => [
+                [
+                    'FINAL',
+                    'const',
+                    PropertyGenerator::FLAG_CONSTANT |
+                    PropertyGenerator::FLAG_PUBLIC |
+                    PropertyGenerator::FLAG_FINAL,
+                ],
+            ],
+        ])]]></code>
+      <code><![CDATA[ClassGenerator::fromArray([
+            'name'     => 'SampleClass',
+            'docblock' => [
+                'shortdescription' => 'foo',
+            ],
+        ])]]></code>
+      <code><![CDATA[ClassGenerator::fromArray([
+            'name'     => 'SampleClass',
+            'docblock' => new DocBlockGenerator('foo'),
+        ])]]></code>
+      <code><![CDATA[ClassGenerator::fromArray([
+            'name'  => 'SomeClass',
+            'flags' => ClassGenerator::FLAG_FINAL | ClassGenerator::FLAG_READONLY,
+        ])]]></code>
+      <code><![CDATA[ClassGenerator::fromArray([
+            'name'  => 'SomeClass',
+            'flags' => ClassGenerator::FLAG_FINAL,
+        ])]]></code>
+    </DeprecatedMethod>
+    <InvalidArgument>
       <code>$reflClass</code>
       <code>$reflClass</code>
       <code>$reflClass</code>
@@ -993,9 +1183,9 @@
       <code>$reflector</code>
       <code>$reflector</code>
       <code>$reflector</code>
-      <code>''</code>
-      <code>'public'</code>
-      <code>'public'</code>
+      <code><![CDATA['']]></code>
+      <code><![CDATA['public']]></code>
+      <code><![CDATA['public']]></code>
       <code>ExceptionInterface::class</code>
       <code>[]</code>
       <code>new ClassGenerator()</code>
@@ -1006,28 +1196,28 @@
       <code>true</code>
       <code>true</code>
     </InvalidArgument>
-    <InvalidCast occurrences="2">
+    <InvalidCast>
       <code>[]</code>
       <code>new ClassGenerator()</code>
     </InvalidCast>
-    <MissingDependency occurrences="2">
+    <MissingDependency>
       <code>FooClass</code>
       <code>FooClass</code>
     </MissingDependency>
-    <MixedArgument occurrences="6">
-      <code>$overrides['myTrait::foo']</code>
-      <code>$overrides['myTrait::foo']</code>
-      <code>$overrides['myTrait::foo']</code>
-      <code>$overrides['myTrait::foo']</code>
+    <MixedArgument>
+      <code><![CDATA[$overrides['myTrait::foo']]]></code>
+      <code><![CDATA[$overrides['myTrait::foo']]]></code>
+      <code><![CDATA[$overrides['myTrait::foo']]]></code>
+      <code><![CDATA[$overrides['myTrait::foo']]]></code>
       <code>FooClass::class</code>
       <code>FooClass::class</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="3">
-      <code>$overrides['myTrait::foo'][0]</code>
-      <code>$overrides['myTrait::foo'][1]</code>
-      <code>$overrides['myTrait::foo'][1]</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$overrides['myTrait::foo'][0]]]></code>
+      <code><![CDATA[$overrides['myTrait::foo'][1]]]></code>
+      <code><![CDATA[$overrides['myTrait::foo'][1]]]></code>
     </MixedArrayAccess>
-    <PossiblyFalseReference occurrences="15">
+    <PossiblyFalseReference>
       <code>getDefaultValue</code>
       <code>getDefaultValue</code>
       <code>getDefaultValue</code>
@@ -1044,59 +1234,59 @@
       <code>getDefaultValue</code>
       <code>getDefaultValue</code>
     </PossiblyFalseReference>
-    <UndefinedClass occurrences="1">
-      <code>['Class1', 'Class2']</code>
+    <UndefinedClass>
+      <code><![CDATA[['Class1', 'Class2']]]></code>
     </UndefinedClass>
   </file>
   <file src="test/Generator/DocBlock/Tag/AuthorTagTest.php">
-    <MissingReturnType occurrences="5">
+    <MissingReturnType>
       <code>testConstructorWithOptions</code>
       <code>testCreatingTagFromReflection</code>
       <code>testGetterAndSetterPersistValue</code>
       <code>testNameIsCorrect</code>
       <code>testParamProducesCorrectDocBlockLine</code>
     </MissingReturnType>
-    <PossiblyFalseArgument occurrences="1">
+    <PossiblyFalseArgument>
       <code>$reflectionTag</code>
     </PossiblyFalseArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="test/Generator/DocBlock/Tag/GenericTagTest.php">
-    <MissingReturnType occurrences="4">
+    <MissingReturnType>
       <code>testConstructorWithOptions</code>
       <code>testCreatingTagFromReflection</code>
       <code>testGetterAndSetterPersistValue</code>
       <code>testParamProducesCorrectDocBlockLine</code>
     </MissingReturnType>
-    <PossiblyFalseArgument occurrences="1">
+    <PossiblyFalseArgument>
       <code>$reflectionTag</code>
     </PossiblyFalseArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="test/Generator/DocBlock/Tag/LicenseTagTest.php">
-    <MissingReturnType occurrences="5">
+    <MissingReturnType>
       <code>testConstructorWithOptions</code>
       <code>testCreatingTagFromReflection</code>
       <code>testGetterAndSetterPersistValue</code>
       <code>testLicenseProducesCorrectDocBlockLine</code>
       <code>testNameIsCorrect</code>
     </MissingReturnType>
-    <PossiblyFalseArgument occurrences="1">
+    <PossiblyFalseArgument>
       <code>$reflectionTag</code>
     </PossiblyFalseArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="test/Generator/DocBlock/Tag/MethodTagTest.php">
-    <MissingReturnType occurrences="6">
+    <MissingReturnType>
       <code>testConstructorWithOptions</code>
       <code>testCreatingTagFromReflection</code>
       <code>testGetterAndSetterPersistValue</code>
@@ -1104,16 +1294,16 @@
       <code>testNameIsCorrect</code>
       <code>testParamProducesCorrectDocBlockLine</code>
     </MissingReturnType>
-    <PossiblyFalseArgument occurrences="1">
+    <PossiblyFalseArgument>
       <code>$reflectionTag</code>
     </PossiblyFalseArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="test/Generator/DocBlock/Tag/ParamTagTest.php">
-    <MissingReturnType occurrences="6">
+    <MissingReturnType>
       <code>testConstructorWithOptions</code>
       <code>testCreatingTagFromReflection</code>
       <code>testGetterAndSetterPersistValue</code>
@@ -1121,16 +1311,16 @@
       <code>testNameIsCorrect</code>
       <code>testParamProducesCorrectDocBlockLine</code>
     </MissingReturnType>
-    <PossiblyFalseArgument occurrences="1">
+    <PossiblyFalseArgument>
       <code>$reflectionTag</code>
     </PossiblyFalseArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="test/Generator/DocBlock/Tag/PropertyTagTest.php">
-    <MissingReturnType occurrences="6">
+    <MissingReturnType>
       <code>testConstructorWithOptions</code>
       <code>testCreatingTagFromReflection</code>
       <code>testGetterAndSetterPersistValue</code>
@@ -1138,44 +1328,44 @@
       <code>testNameIsCorrect</code>
       <code>testParamProducesCorrectDocBlockLine</code>
     </MissingReturnType>
-    <PossiblyFalseArgument occurrences="1">
+    <PossiblyFalseArgument>
       <code>$reflectionTag</code>
     </PossiblyFalseArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="test/Generator/DocBlock/Tag/ReturnTagTest.php">
-    <MissingReturnType occurrences="3">
+    <MissingReturnType>
       <code>testCreatingTagFromReflection</code>
       <code>testNameIsCorrect</code>
       <code>testReturnProducesCorrectDocBlockLine</code>
     </MissingReturnType>
-    <PossiblyFalseArgument occurrences="1">
+    <PossiblyFalseArgument>
       <code>$reflectionTag</code>
     </PossiblyFalseArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="test/Generator/DocBlock/Tag/ThrowsTagTest.php">
-    <MissingReturnType occurrences="3">
+    <MissingReturnType>
       <code>testCreatingTagFromReflection</code>
       <code>testNameIsCorrect</code>
       <code>testParamProducesCorrectDocBlockLine</code>
     </MissingReturnType>
-    <PossiblyFalseArgument occurrences="1">
+    <PossiblyFalseArgument>
       <code>$reflectionTag</code>
     </PossiblyFalseArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="test/Generator/DocBlock/Tag/TypableTagTest.php">
-    <MissingReturnType occurrences="6">
+    <MissingReturnType>
       <code>testConstructorWithOptions</code>
       <code>testGetterAndSetterPersistValue</code>
       <code>testGetterForTypesAsStringWithMultipleTypes</code>
@@ -1183,16 +1373,26 @@
       <code>testGetterForTypesAsStringWithSingleType</code>
       <code>testGetterForTypesAsStringWithSingleTypeAndDelimiter</code>
     </MissingReturnType>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="test/Generator/DocBlockGeneratorTest.php">
-    <DeprecatedMethod occurrences="3">
+    <DeprecatedMethod>
+      <code><![CDATA[DocBlockGenerator::fromArray([
+            'shortdescription' => 'foo',
+            'longdescription'  => 'bar',
+            'tags'             => [
+                [
+                    'name'        => 'foo',
+                    'description' => 'bar',
+                ],
+            ],
+        ])]]></code>
       <code>setDatatype</code>
       <code>setDatatype</code>
     </DeprecatedMethod>
-    <MissingReturnType occurrences="15">
+    <MissingReturnType>
       <code>testCanPassTagsToConstructor</code>
       <code>testCreateFromArray</code>
       <code>testDocBlockFromReflectionAuthorTag</code>
@@ -1210,12 +1410,85 @@
       <code>testTagGettersAndSetters</code>
     </MissingReturnType>
   </file>
+  <file src="test/Generator/EnumGeneratorTest.php">
+    <PossiblyUnusedMethod>
+      <code>validEnumSpecifications</code>
+      <code>validOptionSpecifications</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/Generator/FileGeneratorTest.php">
-    <DeprecatedMethod occurrences="9"/>
-    <InvalidArgument occurrences="1">
-      <code>$file-&gt;getUses()</code>
+    <DeprecatedMethod>
+      <code><![CDATA[FileGenerator::fromArray([
+            'class' => [
+                'name' => 'SampleClass',
+            ],
+        ])]]></code>
+      <code><![CDATA[FileGenerator::fromArray([
+            'declares' => [
+                'fubar' => 1,
+            ],
+            'class'    => [
+                'name' => 'SampleClass',
+            ],
+        ])]]></code>
+      <code><![CDATA[FileGenerator::fromArray([
+            'declares' => [
+                'strict_types' => 'wrong type',
+            ],
+            'class'    => [
+                'name' => 'SampleClass',
+            ],
+        ])]]></code>
+      <code><![CDATA[FileGenerator::fromArray([
+            'declares' => [
+                'strict_types' => 1,
+                'ticks'        => 2,
+            ],
+            'class'    => [
+                'name' => 'SampleClass',
+            ],
+        ])]]></code>
+      <code><![CDATA[FileGenerator::fromArray([
+            'declares' => [
+                'strict_types' => 1,
+            ],
+            'class'    => [
+                'name' => 'SampleClass',
+            ],
+        ])]]></code>
+      <code><![CDATA[FileGenerator::fromArray([
+            'filename' => 'foo.php',
+            'class'    => [
+                'name' => 'bar',
+            ],
+        ])]]></code>
+      <code><![CDATA[FileGenerator::fromArray([
+            'filename' => 'foo.php',
+            'class'    => new ClassGenerator('bar'),
+        ])]]></code>
+      <code><![CDATA[FileGenerator::fromArray([
+            'requiredFiles' => ['SampleClass.php'],
+            'class'         => [
+                'abstract'              => true,
+                'name'                  => 'SampleClass',
+                'extendedClass'         => 'ExtendedClassName',
+                'implementedInterfaces' => ['Iterator', 'Traversable'],
+            ],
+        ])]]></code>
+      <code><![CDATA[FileGenerator::fromArray([
+            'requiredFiles' => ['SampleClass.php'],
+            'class'         => [
+                'flags'                 => ClassGenerator::FLAG_ABSTRACT,
+                'name'                  => 'SampleClass',
+                'extendedClass'         => 'ExtendedClassName',
+                'implementedInterfaces' => ['Iterator', 'Traversable'],
+            ],
+        ])]]></code>
+    </DeprecatedMethod>
+    <InvalidArgument>
+      <code><![CDATA[$file->getUses()]]></code>
     </InvalidArgument>
-    <MissingReturnType occurrences="16">
+    <MissingReturnType>
       <code>testClassNotFoundException</code>
       <code>testConstruction</code>
       <code>testCreateFromArrayWithClassFromArray</code>
@@ -1235,15 +1508,32 @@
     </MissingReturnType>
   </file>
   <file src="test/Generator/InterfaceGeneratorTest.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>['Class1', 'Class2']</code>
+    <ArgumentTypeCoercion>
+      <code><![CDATA[['Class1', 'Class2']]]></code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="3"/>
-    <InvalidArgument occurrences="2">
+    <DeprecatedMethod>
+      <code><![CDATA[InterfaceGenerator::fromArray([
+            'name'     => 'MyInterface',
+            'docblock' => new DocBlockGenerator('foo'),
+        ])]]></code>
+      <code><![CDATA[InterfaceGenerator::fromArray([
+            'name'     => 'SampleClass',
+            'docblock' => [
+                'shortdescription' => 'foo',
+            ],
+        ])]]></code>
+      <code><![CDATA[InterfaceGenerator::fromArray([
+            'name'    => 'SampleInterface',
+            'methods' => [
+                ['name' => 'baz'],
+            ],
+        ])]]></code>
+    </DeprecatedMethod>
+    <InvalidArgument>
       <code>$reflClass</code>
       <code>new ClassReflection(self::class)</code>
     </InvalidArgument>
-    <MissingReturnType occurrences="17">
+    <MissingReturnType>
       <code>testAbstractAccessorsReturnsFalse</code>
       <code>testClassNotAnInterfaceException</code>
       <code>testCodeGenerationShouldTakeIntoAccountNamespacesFromReflection</code>
@@ -1262,27 +1552,50 @@
       <code>testSetextendedclassShouldNotIgnoreNonEmptyClassnameOnGenerate</code>
       <code>testToString</code>
     </MissingReturnType>
-    <PossiblyFalseReference occurrences="2">
+    <PossiblyFalseReference>
       <code>isInterface</code>
       <code>isInterface</code>
     </PossiblyFalseReference>
-    <UndefinedClass occurrences="1">
-      <code>['Class1', 'Class2']</code>
+    <UndefinedClass>
+      <code><![CDATA[['Class1', 'Class2']]]></code>
     </UndefinedClass>
   </file>
   <file src="test/Generator/MethodGeneratorTest.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion>
       <code>$className</code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="6">
-      <code>ParameterGenerator::fromArray(['name' =&gt; 'bar', 'type' =&gt; 'array'])</code>
-      <code>ParameterGenerator::fromArray(['name' =&gt; 'baz', 'type' =&gt; stdClass::class, 'position' =&gt; 1])</code>
-      <code>ParameterGenerator::fromArray(['name' =&gt; 'baz', 'type' =&gt; stdClass::class])</code>
+    <DeprecatedMethod>
+      <code><![CDATA[MethodGenerator::fromArray([
+            'name'             => 'SampleMethod',
+            'returnsreference' => $value,
+        ])]]></code>
+      <code><![CDATA[MethodGenerator::fromArray([
+            'name'       => 'SampleMethod',
+            'body'       => 'foo',
+            'docblock'   => [
+                'shortdescription' => 'foo',
+            ],
+            'abstract'   => true,
+            'final'      => true,
+            'static'     => true,
+            'visibility' => MethodGenerator::VISIBILITY_PROTECTED,
+            'returntype' => '\\SampleType',
+        ])]]></code>
+      <code><![CDATA[MethodGenerator::fromArray([
+            'name'      => 'execute',
+            'interface' => true,
+            'docblock'  => [
+                'shortdescription' => 'Short Description',
+            ],
+        ])]]></code>
+      <code><![CDATA[ParameterGenerator::fromArray(['name' => 'bar', 'type' => 'array'])]]></code>
+      <code><![CDATA[ParameterGenerator::fromArray(['name' => 'baz', 'type' => stdClass::class, 'position' => 1])]]></code>
+      <code><![CDATA[ParameterGenerator::fromArray(['name' => 'baz', 'type' => stdClass::class])]]></code>
     </DeprecatedMethod>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>new stdClass()</code>
     </InvalidArgument>
-    <MissingReturnType occurrences="22">
+    <MissingReturnType>
       <code>testByRefReturnType</code>
       <code>testCopyMethodSignature</code>
       <code>testCreateFromArray</code>
@@ -1306,28 +1619,51 @@
       <code>testSetReturnType</code>
       <code>testSetReturnTypeWithNull</code>
     </MissingReturnType>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>generate</code>
     </PossiblyNullReference>
+    <PossiblyUnusedMethod>
+      <code>php80Methods</code>
+      <code>returnTypeHintClasses</code>
+      <code>returnsReferenceValues</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/Generator/ParameterGeneratorTest.php">
-    <ArgumentTypeCoercion occurrences="2">
-      <code>'LaminasTest_Code_NsTest_BarClass'</code>
-      <code>'Namespaced\TypeHint\Bar'</code>
+    <ArgumentTypeCoercion>
+      <code><![CDATA['LaminasTest_Code_NsTest_BarClass']]></code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="1"/>
-    <InvalidReturnStatement occurrences="1"/>
-    <InvalidReturnType occurrences="1">
+    <DeprecatedMethod>
+      <code><![CDATA[ParameterGenerator::fromArray([
+            'name'              => 'SampleParameter',
+            'type'              => 'int',
+            'defaultvalue'      => 'default-foo',
+            'passedbyreference' => false,
+            'position'          => 1,
+            'sourcedirty'       => false,
+            'sourcecontent'     => 'foo',
+            'indentation'       => '-',
+            'omitdefaultvalue'  => true,
+        ])]]></code>
+    </DeprecatedMethod>
+    <InvalidReturnStatement>
+      <code><![CDATA[array_combine(
+            array_map(
+                static fn(array $definition) => $definition[0] . '#' . $definition[1],
+                $parameters
+            ),
+            $parameters
+        )]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
       <code>string[][]</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="25">
+    <MissingReturnType>
       <code>testCallableTypeHint</code>
       <code>testCreateFromArray</code>
       <code>testDefaultValueGetterAndSetterPersistValue</code>
       <code>testFromReflectionGenerate</code>
       <code>testFromReflectionGetArrayHint</code>
       <code>testFromReflectionGetDefaultValue</code>
-      <code>testFromReflectionGetDefaultValueNotOptional</code>
       <code>testFromReflectionGetParameterName</code>
       <code>testFromReflectionGetParameterType</code>
       <code>testFromReflectionGetReference</code>
@@ -1347,50 +1683,127 @@
       <code>testTypeHintWithValidClassName</code>
       <code>testTypehintsWithNamespaceInNamepsacedClassReturnTypewithBackslash</code>
     </MissingReturnType>
+    <PossiblyUnusedMethod>
+      <code>dataFromReflectionGenerate</code>
+      <code>php80Methods</code>
+      <code>reflectionHints</code>
+      <code>simpleHints</code>
+      <code>validClassName</code>
+      <code>variadicHints</code>
+    </PossiblyUnusedMethod>
+    <UnusedMethodCall>
+      <code>setAccessible</code>
+    </UnusedMethodCall>
   </file>
   <file src="test/Generator/PropertyGeneratorTest.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion>
       <code>$type</code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="3"/>
-    <InvalidArgument occurrences="1">
+    <DeprecatedMethod>
+      <code><![CDATA[PropertyGenerator::fromArray([
+            'name'             => 'SampleProperty',
+            'const'            => false,
+            'defaultvalue'     => 'default-foo',
+            'docblock'         => [
+                'shortdescription' => 'foo',
+            ],
+            'abstract'         => true,
+            'final'            => true,
+            'static'           => true,
+            'visibility'       => PropertyGenerator::VISIBILITY_PROTECTED,
+            'omitdefaultvalue' => true,
+            'type'             => TypeGenerator::fromTypeString(self::class),
+        ])]]></code>
+      <code><![CDATA[PropertyGenerator::fromArray([
+            'name'     => 'ReadonlyProperty',
+            'readonly' => true,
+        ])]]></code>
+      <code><![CDATA[PropertyGenerator::fromArray([
+            'name' => 'someVal',
+            'type' => 'invalidStringn',
+        ])]]></code>
+    </DeprecatedMethod>
+    <InvalidArgument>
       <code>new stdClass()</code>
     </InvalidArgument>
-    <InvalidReturnStatement occurrences="1"/>
-    <InvalidReturnType occurrences="1">
+    <InvalidReturnStatement>
+      <code><![CDATA[[
+            ['string', 'foo', "'foo';"],
+            ['int', 1, '1;'],
+            ['integer', 1, '1;'],
+            ['bool', true, 'true;'],
+            ['bool', false, 'false;'],
+            ['boolean', true, 'true;'],
+            ['number', 1, '1;'],
+            ['float', 1.23, '1.23;'],
+            ['double', 1.23, '1.23;'],
+            ['constant', 'FOO', 'FOO;'],
+            ['null', null, 'null;'],
+        ]]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
       <code>bool[][]|string[][]|int[][]|null[][]</code>
     </InvalidReturnType>
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>testOmitType</code>
     </MissingReturnType>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$generator</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>Generator</code>
-    </MixedInferredReturnType>
-    <PossiblyInvalidArgument occurrences="5">
-      <code>testSetBogusTypeSetValueGenerateUseAutoDetection</code>
-      <code>testSetBogusTypeSetValueGenerateUseAutoDetection</code>
-      <code>testSetDefaultValue</code>
-      <code>testSetTypeSetValueGenerate</code>
-      <code>testSetTypeSetValueGenerate</code>
-    </PossiblyInvalidArgument>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <PossiblyUnusedMethod>
+      <code>dataSetTypeSetValueGenerate</code>
+      <code>visibility</code>
+    </PossiblyUnusedMethod>
+    <RedundantConditionGivenDocblockType>
       <code>assertIsArray</code>
     </RedundantConditionGivenDocblockType>
+    <UnusedMethodCall>
+      <code>setAccessible</code>
+    </UnusedMethodCall>
   </file>
   <file src="test/Generator/PropertyValueGeneratorTest.php">
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>testPropertyValueAddsSemicolonToValueGenerator</code>
     </MissingReturnType>
   </file>
   <file src="test/Generator/TraitGeneratorTest.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>'LaminasTest_Code_NsTest_BarClass'</code>
+    <ArgumentTypeCoercion>
+      <code><![CDATA['LaminasTest_Code_NsTest_BarClass']]></code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="6"/>
-    <InvalidArgument occurrences="8">
+    <DeprecatedMethod>
+      <code><![CDATA[TraitGenerator::fromArray([
+            'docblock' => new DocBlockGenerator('foo'),
+        ])]]></code>
+      <code><![CDATA[TraitGenerator::fromArray([
+            'name'           => 'SampleClass',
+            'containingfile' => new FileGenerator(),
+        ])]]></code>
+      <code><![CDATA[TraitGenerator::fromArray([
+            'name'          => 'SampleClass',
+            'namespacename' => $namespace,
+        ])]]></code>
+      <code><![CDATA[TraitGenerator::fromArray([
+            'name'       => 'SampleClass',
+            'properties' => [
+                'foo',
+                ['name' => 'bar'],
+            ],
+            'methods'    => [
+                ['name' => 'baz'],
+            ],
+        ])]]></code>
+      <code><![CDATA[TraitGenerator::fromArray([
+            'name'     => 'SampleClass',
+            'docblock' => [
+                'shortdescription' => 'foo',
+            ],
+        ])]]></code>
+      <code><![CDATA[TraitGenerator::fromArray([
+            'name'     => 'SampleClass',
+            'docblock' => new DocBlockGenerator('foo'),
+        ])]]></code>
+    </DeprecatedMethod>
+    <InvalidArgument>
       <code>$reflClass</code>
       <code>$reflClass</code>
       <code>$reflClass</code>
@@ -1400,32 +1813,48 @@
       <code>true</code>
       <code>true</code>
     </InvalidArgument>
+    <UnusedMethodCall>
+      <code>setAccessible</code>
+    </UnusedMethodCall>
   </file>
   <file src="test/Generator/TypeGenerator/CompositeTypeTest.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>iterable</code>
-    </MixedInferredReturnType>
+    <PossiblyUnusedMethod>
+      <code>validType</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/Generator/TypeGenerator/IntersectionTypeTest.php">
+    <PossiblyUnusedMethod>
+      <code>invalidIntersectionsExamples</code>
+      <code>sortingExamples</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/Generator/TypeGenerator/UnionTypeTest.php">
+    <PossiblyUnusedMethod>
+      <code>invalidUnionsExamples</code>
+      <code>sortingExamples</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/Generator/TypeGeneratorTest.php">
-    <MissingReturnType occurrences="4">
-      <code>testFromValidTypeString</code>
+    <MissingReturnType>
       <code>testIsAGenerator</code>
-      <code>testRejectsInvalidTypeString</code>
-      <code>testStringCastFromValidTypeString</code>
     </MissingReturnType>
+    <PossiblyUnusedMethod>
+      <code>invalidType</code>
+      <code>validClassName</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/Generator/ValueGeneratorTest.php">
-    <DeprecatedMethod occurrences="5">
+    <DeprecatedMethod>
       <code>getConstants</code>
       <code>getConstants</code>
       <code>initEnvironmentConstants</code>
       <code>initEnvironmentConstants</code>
       <code>initEnvironmentConstants</code>
     </DeprecatedMethod>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$constants</code>
     </InvalidArgument>
-    <MissingReturnType occurrences="9">
+    <MissingReturnType>
       <code>testEscaping</code>
       <code>testPropertyDefaultValueCanHandleArray</code>
       <code>testPropertyDefaultValueCanHandleArrayWithUnsortedKeys</code>
@@ -1436,33 +1865,30 @@
       <code>testPropertyDefaultValueConstructor</code>
       <code>testPropertyDefaultValueIsSettable</code>
     </MissingReturnType>
-    <MixedInferredReturnType occurrences="5">
-      <code>Generator</code>
-      <code>array</code>
-      <code>array</code>
-      <code>array</code>
-      <code>array</code>
-    </MixedInferredReturnType>
+    <PossiblyUnusedMethod>
+      <code>complexArray</code>
+      <code>complexArrayWCustomIndent</code>
+      <code>constantsType</code>
+      <code>getEscapedParameters</code>
+      <code>invalidValue</code>
+      <code>simpleArray</code>
+      <code>unsortedKeysArray</code>
+      <code>validConstantTypes</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/Generic/Prototype/PrototypeClassFactoryTest.php">
-    <DeprecatedMethod occurrences="1">
-      <code>setMethods</code>
-    </DeprecatedMethod>
-    <MissingReturnType occurrences="3">
+    <MissingReturnType>
       <code>testAddAndGetPrototype</code>
       <code>testFallBackToGeneric</code>
       <code>testSetNameOnGenericIsCalledOnce</code>
     </MissingReturnType>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="test/Reflection/ClassReflectionTest.php">
-    <ArgumentTypeCoercion occurrences="2">
-      <code>'ReflectionClass'</code>
-      <code>__NAMESPACE__ . '\\' . $className</code>
+    <ArgumentTypeCoercion>
+      <code><![CDATA['ReflectionClass']]></code>
+      <code><![CDATA[__NAMESPACE__ . '\\' . $className]]></code>
     </ArgumentTypeCoercion>
-    <MissingReturnType occurrences="10">
+    <MissingReturnType>
       <code>testGetContentsReturnsContents</code>
       <code>testGetContentsReturnsContentsWithImplementsOnSeparateLine</code>
       <code>testGetContentsReturnsEmptyContentsOnEvaldCode</code>
@@ -1474,42 +1900,39 @@
       <code>testPropertyReturns</code>
       <code>testStartLine</code>
     </MissingReturnType>
-    <PossiblyFalseArgument occurrences="1">
-      <code>$parent</code>
-    </PossiblyFalseArgument>
-    <PossiblyFalseReference occurrences="1">
+    <PossiblyFalseReference>
       <code>getName</code>
     </PossiblyFalseReference>
-    <PossiblyInvalidArrayOffset occurrences="1">
+    <PossiblyInvalidArrayOffset>
       <code>$traitsArray[TestTraitClass3::class]</code>
     </PossiblyInvalidArrayOffset>
   </file>
   <file src="test/Reflection/DocBlock/Tag/AuthorTagTest.php">
-    <MissingReturnType occurrences="2">
+    <MissingReturnType>
       <code>testParseName</code>
       <code>testParseNameAndEmail</code>
     </MissingReturnType>
   </file>
   <file src="test/Reflection/DocBlock/Tag/GenericTagTest.php">
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>testParse</code>
     </MissingReturnType>
   </file>
   <file src="test/Reflection/DocBlock/Tag/LicenseTagTest.php">
-    <MissingReturnType occurrences="2">
+    <MissingReturnType>
       <code>testParseUrl</code>
       <code>testParseUrlAndLicenseName</code>
     </MissingReturnType>
   </file>
   <file src="test/Reflection/DocBlock/Tag/MethodTagTest.php">
-    <DeprecatedMethod occurrences="5">
+    <DeprecatedMethod>
       <code>getReturnType</code>
       <code>getReturnType</code>
       <code>getReturnType</code>
       <code>getReturnType</code>
       <code>getReturnType</code>
     </DeprecatedMethod>
-    <MissingReturnType occurrences="5">
+    <MissingReturnType>
       <code>testParseName</code>
       <code>testParseNameAndStatic</code>
       <code>testParseNameAndStaticAndDescription</code>
@@ -1518,13 +1941,13 @@
     </MissingReturnType>
   </file>
   <file src="test/Reflection/DocBlock/Tag/PropertyTagTest.php">
-    <DeprecatedMethod occurrences="4">
+    <DeprecatedMethod>
       <code>getType</code>
       <code>getType</code>
       <code>getType</code>
       <code>getType</code>
     </DeprecatedMethod>
-    <MissingReturnType occurrences="4">
+    <MissingReturnType>
       <code>testParseName</code>
       <code>testParseNameAndDescription</code>
       <code>testParseTypeAndName</code>
@@ -1532,7 +1955,7 @@
     </MissingReturnType>
   </file>
   <file src="test/Reflection/DocBlock/Tag/ThrowsTagTest.php">
-    <MissingReturnType occurrences="5">
+    <MissingReturnType>
       <code>testAllCharactersFromTypenameAreSupported</code>
       <code>testMultipleTypesWithDescription</code>
       <code>testMultipleTypesWithoutDescription</code>
@@ -1541,22 +1964,22 @@
     </MissingReturnType>
   </file>
   <file src="test/Reflection/DocBlock/Tag/VarTagTest.php">
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>testParse</code>
     </MissingReturnType>
-    <MixedInferredReturnType occurrences="1">
-      <code>array</code>
-    </MixedInferredReturnType>
+    <PossiblyUnusedMethod>
+      <code>varTagProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/Reflection/DocBlockReflectionTest.php">
-    <DeprecatedMethod occurrences="5">
+    <DeprecatedMethod>
       <code>getType</code>
       <code>getType</code>
       <code>getType</code>
       <code>getType</code>
       <code>getType</code>
     </DeprecatedMethod>
-    <MissingReturnType occurrences="9">
+    <MissingReturnType>
       <code>testDocBlockContents</code>
       <code>testDocBlockLines</code>
       <code>testDocBlockLongDescription</code>
@@ -1567,7 +1990,7 @@
       <code>testTabbedDocBlockTags</code>
       <code>testToString</code>
     </MissingReturnType>
-    <PossiblyFalseReference occurrences="26">
+    <PossiblyFalseReference>
       <code>getContents</code>
       <code>getLongDescription</code>
       <code>getShortDescription</code>
@@ -1595,7 +2018,7 @@
       <code>hasTag</code>
       <code>hasTag</code>
     </PossiblyFalseReference>
-    <UndefinedInterfaceMethod occurrences="4">
+    <UndefinedInterfaceMethod>
       <code>getDescription</code>
       <code>getType</code>
       <code>getType</code>
@@ -1603,39 +2026,44 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reflection/FunctionReflectionTest.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>__NAMESPACE__ . '\\' . $functionName</code>
+    <ArgumentTypeCoercion>
+      <code><![CDATA[__NAMESPACE__ . '\\' . $functionName]]></code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="2">
+    <DeprecatedMethod>
       <code>getPrototype</code>
       <code>getPrototype</code>
     </DeprecatedMethod>
-    <InvalidArgument occurrences="23">
-      <code>'LaminasTest\Code\Reflection\TestAsset\function1'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function1'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function10'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function10'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function11'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function11'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function12'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function12'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function2'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function3'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function3'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function4'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function4'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function5'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function5'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function6'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function6'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function7'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function7'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function8'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function8'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function9'</code>
-      <code>'LaminasTest\Code\Reflection\TestAsset\function9'</code>
+    <EmptyArrayAccess>
+      <code><![CDATA[$list1['closure']]]></code>
+      <code>$list2[0]</code>
+      <code>$list3[0]</code>
+    </EmptyArrayAccess>
+    <InvalidArgument>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function1']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function1']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function10']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function10']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function11']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function11']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function12']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function12']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function2']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function3']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function3']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function4']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function4']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function5']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function5']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function6']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function6']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function7']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function7']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function8']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function8']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function9']]></code>
+      <code><![CDATA['LaminasTest\Code\Reflection\TestAsset\function9']]></code>
     </InvalidArgument>
-    <MissingReturnType occurrences="13">
+    <MissingReturnType>
       <code>testFunctionBodyReturn</code>
       <code>testFunctionClosureBodyReturn</code>
       <code>testFunctionClosureContentsReturnWithDocBlock</code>
@@ -1650,7 +2078,17 @@
       <code>testInternalFunctionContentsReturn</code>
       <code>testParemeterReturn</code>
     </MissingReturnType>
-    <MixedArgument occurrences="14">
+    <MixedArgument>
+      <code>$function5</code>
+      <code>$function6</code>
+      <code>$function7</code>
+    </MixedArgument>
+    <MixedAssignment>
+      <code>$function5</code>
+      <code>$function6</code>
+      <code>$function7</code>
+    </MixedAssignment>
+    <NullArgument>
       <code>$function1</code>
       <code>$function10</code>
       <code>$function10</code>
@@ -1658,25 +2096,12 @@
       <code>$function2</code>
       <code>$function3</code>
       <code>$function4</code>
-      <code>$function5</code>
-      <code>$function6</code>
-      <code>$function7</code>
       <code>$function8</code>
       <code>$function9</code>
       <code>$function9</code>
       <code>$function9</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="3">
-      <code>$list1['closure']</code>
-      <code>$list2[0]</code>
-      <code>$list3[0]</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
-      <code>$function5</code>
-      <code>$function6</code>
-      <code>$function7</code>
-    </MixedAssignment>
-    <PossiblyFalseArgument occurrences="18">
+    </NullArgument>
+    <PossiblyFalseArgument>
       <code>$body</code>
       <code>$body</code>
       <code>$body</code>
@@ -1696,34 +2121,18 @@
       <code>$body</code>
       <code>$body</code>
     </PossiblyFalseArgument>
-    <UndefinedVariable occurrences="14">
-      <code>$function1</code>
-      <code>$function10</code>
-      <code>$function10</code>
-      <code>$function2</code>
-      <code>$function2</code>
-      <code>$function3</code>
-      <code>$function4</code>
-      <code>$function8</code>
-      <code>$function9</code>
-      <code>$function9</code>
-      <code>$function9</code>
-      <code>$list1</code>
-      <code>$list2</code>
-      <code>$list3</code>
-    </UndefinedVariable>
   </file>
   <file src="test/Reflection/MethodReflectionTest.php">
-    <ArgumentTypeCoercion occurrences="7">
-      <code>'DOMDocument'</code>
-      <code>'DOMDocument'</code>
-      <code>'DateTime'</code>
-      <code>'FooClass'</code>
-      <code>'ReflectionClass'</code>
-      <code>'ReflectionException'</code>
-      <code>__NAMESPACE__ . '\\' . $className</code>
+    <ArgumentTypeCoercion>
+      <code><![CDATA['DOMDocument']]></code>
+      <code><![CDATA['DOMDocument']]></code>
+      <code><![CDATA['DateTime']]></code>
+      <code><![CDATA['FooClass']]></code>
+      <code><![CDATA['ReflectionClass']]></code>
+      <code><![CDATA['ReflectionException']]></code>
+      <code><![CDATA[__NAMESPACE__ . '\\' . $className]]></code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="8">
+    <DeprecatedMethod>
       <code>getPrototype</code>
       <code>getPrototype</code>
       <code>getPrototype</code>
@@ -1733,7 +2142,7 @@
       <code>getPrototype</code>
       <code>getPrototype</code>
     </DeprecatedMethod>
-    <MissingReturnType occurrences="15">
+    <MissingReturnType>
       <code>testCanParseClassBodyWhenUsingTrait</code>
       <code>testCodeGetBodyReturnsEmptyWithCommentedFunction</code>
       <code>testCodeGetContentsDoesNotThrowExceptionOnDocBlock</code>
@@ -1752,35 +2161,36 @@
     </MissingReturnType>
   </file>
   <file src="test/Reflection/ParameterReflectionTest.php">
-    <DeprecatedMethod occurrences="5">
+    <DeprecatedMethod>
       <code>detectType</code>
       <code>detectType</code>
       <code>detectType</code>
       <code>detectType</code>
       <code>detectType</code>
     </DeprecatedMethod>
-    <MissingReturnType occurrences="9">
+    <MissingReturnType>
       <code>testCallableTypeHint</code>
       <code>testClassReturn</code>
       <code>testClassReturnNoClassGivenReturnsNull</code>
       <code>testDeclaringClassReturn</code>
-      <code>testDetectType</code>
-      <code>testDetectTypeWithDocBlockOnlyTypes</code>
-      <code>testGetType</code>
-      <code>testGetTypeWithDocBlockOnlyTypes</code>
-      <code>testTypeReturn</code>
     </MissingReturnType>
-    <UndefinedMethod occurrences="1">
+    <PossiblyUnusedMethod>
+      <code>docBlockHints</code>
+      <code>paramType</code>
+      <code>paramTypeWithNotAllParamsDeclared</code>
+      <code>reflectionHints</code>
+    </PossiblyUnusedMethod>
+    <UndefinedMethod>
       <code>getName</code>
     </UndefinedMethod>
   </file>
   <file src="test/Reflection/PropertyReflectionTest.php">
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>testDeclaringClassReturn</code>
     </MissingReturnType>
   </file>
   <file src="test/Reflection/ReflectionDocBlockTagTest.php">
-    <MissingReturnType occurrences="12">
+    <MissingReturnType>
       <code>testAllowsMultipleSpacesInDocBlockTagLine</code>
       <code>testAllowsMultipleSpacesInDocBlockTagLine2</code>
       <code>testNamespaceInParam</code>
@@ -1794,10 +2204,7 @@
       <code>testTypeParam</code>
       <code>testVariableName</code>
     </MissingReturnType>
-    <MixedInferredReturnType occurrences="1">
-      <code>array</code>
-    </MixedInferredReturnType>
-    <PossiblyFalseReference occurrences="29">
+    <PossiblyFalseReference>
       <code>getAuthorEmail</code>
       <code>getAuthorName</code>
       <code>getContent</code>
@@ -1828,10 +2235,13 @@
       <code>getVariableName</code>
       <code>getVariableName</code>
     </PossiblyFalseReference>
-    <PossiblyInvalidCast occurrences="1">
+    <PossiblyInvalidCast>
       <code>$tag</code>
     </PossiblyInvalidCast>
-    <UndefinedInterfaceMethod occurrences="16">
+    <PossiblyUnusedMethod>
+      <code>propertyVarDocProvider</code>
+    </PossiblyUnusedMethod>
+    <UndefinedInterfaceMethod>
       <code>getAuthorEmail</code>
       <code>getAuthorName</code>
       <code>getContent</code>
@@ -1851,18 +2261,18 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Scanner/DocBlockScannerTest.php">
-    <MissingReturnType occurrences="3">
+    <MissingReturnType>
       <code>testDocBlockScannerDescriptions</code>
       <code>testDocBlockScannerParsesTagsWithNoValuesProperly</code>
       <code>testInvalidDocBlock</code>
     </MissingReturnType>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$tags[0]</code>
       <code>$tags[0]</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="2">
-      <code>$tags[0]['name']</code>
-      <code>$tags[0]['value']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$tags[0]['name']]]></code>
+      <code><![CDATA[$tags[0]['value']]]></code>
     </MixedArrayAccess>
   </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,6 +5,8 @@
         xmlns="https://getpsalm.org/schema/config"
         xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
         findUnusedPsalmSuppress="true"
+        findUnusedBaselineEntry="true"
+        findUnusedCode="true"
         errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>

--- a/test/Generator/AbstractGeneratorTest.php
+++ b/test/Generator/AbstractGeneratorTest.php
@@ -5,12 +5,11 @@ namespace LaminasTest\Code\Generator;
 use Laminas\Code\Generator\AbstractGenerator;
 use Laminas\Code\Generator\Exception\InvalidArgumentException;
 use Laminas\Code\Generator\GeneratorInterface;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class AbstractGeneratorTest extends TestCase
 {
     public function testConstructor()

--- a/test/Generator/AbstractMemberGeneratorTest.php
+++ b/test/Generator/AbstractMemberGeneratorTest.php
@@ -5,13 +5,13 @@ namespace LaminasTest\Code\Generator;
 use Laminas\Code\Generator\AbstractMemberGenerator;
 use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\Exception\InvalidArgumentException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 class AbstractMemberGeneratorTest extends TestCase
 {
-    /** @var AbstractMemberGenerator */
-    private $fixture;
+    private MockObject&AbstractMemberGenerator $fixture;
 
     protected function setUp(): void
     {

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -16,6 +16,8 @@ use LaminasTest\Code\Generator\TestAsset\ClassWithDnfTypes;
 use LaminasTest\Code\Generator\TestAsset\ClassWithPromotedParameter;
 use LaminasTest\Code\Generator\TestAsset\ReadonlyClassWithPromotedParameter;
 use LaminasTest\Code\TestAsset\FooClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use Serializable;
@@ -27,10 +29,8 @@ use function fclose;
 use function fopen;
 use function key;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class ClassGeneratorTest extends TestCase
 {
     public function testConstruction(): void
@@ -201,9 +201,7 @@ class ClassGeneratorTest extends TestCase
         $classGenerator->addMethodFromGenerator($methodB);
     }
 
-    /**
-     * @group Laminas-7361
-     */
+    #[Group('Laminas-7361')]
     public function testHasMethod(): void
     {
         $classGenerator = new ClassGenerator();
@@ -222,9 +220,7 @@ class ClassGeneratorTest extends TestCase
         self::assertFalse($classGenerator->hasMethod('methodOne'));
     }
 
-    /**
-     * @group Laminas-7361
-     */
+    #[Group('Laminas-7361')]
     public function testHasProperty(): void
     {
         $classGenerator = new ClassGenerator();
@@ -277,9 +273,7 @@ EOS;
         self::assertSame($expectedOutput, $output, $output);
     }
 
-    /**
-     * @group Laminas-7909
-     */
+    #[Group('Laminas-7909')]
     public function testClassFromReflectionThatImplementsInterfaces(): void
     {
         $reflClass = new ClassReflection(TestAsset\ClassWithInterface::class);
@@ -295,9 +289,7 @@ EOS;
         self::assertStringContainsString($expectedClassDef, $code);
     }
 
-    /**
-     * @group Laminas-7909
-     */
+    #[Group('Laminas-7909')]
     public function testClassFromReflectionDiscardParentImplementedInterfaces(): void
     {
         $reflClass = new ClassReflection(TestAsset\NewClassWithInterface::class);
@@ -313,9 +305,7 @@ EOS;
         self::assertStringContainsString($expectedClassDef, $code);
     }
 
-    /**
-     * @group 4988
-     */
+    #[Group('4988')]
     public function testNonNamespaceClassReturnsAllMethods(): void
     {
         require_once __DIR__ . '/../TestAsset/NonNamespaceClass.php';
@@ -325,9 +315,7 @@ EOS;
         self::assertCount(1, $classGenerator->getMethods());
     }
 
-    /**
-     * @group Laminas-9602
-     */
+    #[Group('Laminas-9602')]
     public function testSetextendedclassShouldIgnoreEmptyClassnameOnGenerate(): void
     {
         $classGeneratorClass = new ClassGenerator();
@@ -344,9 +332,7 @@ CODE;
         self::assertSame($expected, $classGeneratorClass->generate());
     }
 
-    /**
-     * @group Laminas-9602
-     */
+    #[Group('Laminas-9602')]
     public function testSetextendedclassShouldNotIgnoreNonEmptyClassnameOnGenerate(): void
     {
         $classGeneratorClass = new ClassGenerator();
@@ -363,9 +349,7 @@ CODE;
         self::assertSame($expected, $classGeneratorClass->generate());
     }
 
-    /**
-     * @group namespace
-     */
+    #[Group('namespace')]
     public function testCodeGenerationShouldTakeIntoAccountNamespacesFromReflection(): void
     {
         $reflClass      = new ClassReflection(TestAsset\ClassWithNamespace::class);
@@ -384,9 +368,7 @@ CODE;
         self::assertSame($expected, $received, $received);
     }
 
-    /**
-     * @group namespace
-     */
+    #[Group('namespace')]
     public function testSetNameShouldDetermineIfNamespaceSegmentIsPresent(): void
     {
         $classGeneratorClass = new ClassGenerator();
@@ -394,9 +376,7 @@ CODE;
         self::assertSame('My\Namespaced', $classGeneratorClass->getNamespaceName());
     }
 
-    /**
-     * @group namespace
-     */
+    #[Group('namespace')]
     public function testPassingANamespacedClassnameShouldGenerateANamespaceDeclaration(): void
     {
         $classGeneratorClass = new ClassGenerator();
@@ -405,9 +385,7 @@ CODE;
         self::assertStringContainsString('namespace My\Namespaced;', $received, $received);
     }
 
-    /**
-     * @group namespace
-     */
+    #[Group('namespace')]
     public function testPassingANamespacedClassnameShouldGenerateAClassnameWithoutItsNamespace(): void
     {
         $classGeneratorClass = new ClassGenerator();
@@ -458,9 +436,7 @@ CODE;
         self::assertFalse($classGenerator->hasUseAlias('My\First\Use\Class'));
     }
 
-    /**
-     * @group Laminas-151
-     */
+    #[Group('Laminas-151')]
     public function testAddUses(): void
     {
         $classGenerator = new ClassGenerator();
@@ -473,9 +449,7 @@ CODE;
         self::assertStringContainsString('use My\Second\Use\Class as MyAlias;', $generated);
     }
 
-    /**
-     * @group 4990
-     */
+    #[Group('4990')]
     public function testAddOneUseTwiceOnlyAddsOne(): void
     {
         $classGenerator = new ClassGenerator();
@@ -489,9 +463,7 @@ CODE;
         self::assertStringContainsString('use My\First\Use\Class;', $generated);
     }
 
-    /**
-     * @group 4990
-     */
+    #[Group('4990')]
     public function testAddOneUseWithAliasTwiceOnlyAddsOne(): void
     {
         $classGenerator = new ClassGenerator();
@@ -580,9 +552,7 @@ CODE;
         self::assertSame($expected, $output);
     }
 
-    /**
-     * @group 6274
-     */
+    #[Group('6274')]
     public function testCanAddConstant(): void
     {
         $classGenerator = new ClassGenerator();
@@ -602,9 +572,7 @@ CODE;
         self::assertSame('value', $defaultValue->getValue());
     }
 
-    /**
-     * @group 6274
-     */
+    #[Group('6274')]
     public function testCanAddConstantsWithArrayOfGenerators(): void
     {
         $classGenerator = new ClassGenerator();
@@ -624,9 +592,7 @@ CODE;
         self::assertSame('value2', $valueY->getValue());
     }
 
-    /**
-     * @group 6274
-     */
+    #[Group('6274')]
     public function testCanAddConstantsWithArrayOfKeyValues(): void
     {
         $classGenerator = new ClassGenerator();
@@ -647,9 +613,7 @@ CODE;
         self::assertSame('value2', $valueY->getValue());
     }
 
-    /**
-     * @group 6274
-     */
+    #[Group('6274')]
     public function testAddConstantThrowsExceptionWithInvalidName(): void
     {
         $classGenerator = new ClassGenerator();
@@ -725,7 +689,7 @@ CODE;
             $classGenerator->addConstant('a', $resource);
 
             $this->fail('Not supposed to be reached');
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             self::assertEmpty($classGenerator->getConstants());
         } finally {
             fclose($resource);
@@ -740,9 +704,7 @@ CODE;
         $classGenerator->addConstant('a', [new stdClass()]);
     }
 
-    /**
-     * @group 6274
-     */
+    #[Group('6274')]
     public function testAddConstantThrowsExceptionOnDuplicate(): void
     {
         $classGenerator = new ClassGenerator();
@@ -762,9 +724,7 @@ CODE;
         self::assertFalse($classGenerator->hasConstant('constantOne'));
     }
 
-    /**
-     * @group 6274
-     */
+    #[Group('6274')]
     public function testAddPropertyIsBackwardsCompatibleWithConstants(): void
     {
         $classGenerator = new ClassGenerator();
@@ -776,9 +736,7 @@ CODE;
         self::assertSame('value1', $valueX->getValue());
     }
 
-    /**
-     * @group 6274
-     */
+    #[Group('6274')]
     public function testAddPropertiesIsBackwardsCompatibleWithConstants(): void
     {
         $constants      = [
@@ -799,9 +757,7 @@ CODE;
         self::assertSame('value2', $valueY->getValue());
     }
 
-    /**
-     * @group 6274
-     */
+    #[Group('6274')]
     public function testConstantsAddedFromReflection(): void
     {
         $reflector      = new ClassReflection(TestAsset\TestClassWithManyProperties::class);
@@ -813,9 +769,7 @@ CODE;
         self::assertSame('foo', $constantValue->getValue());
     }
 
-    /**
-     * @group 6274
-     */
+    #[Group('6274')]
     public function testClassCanBeGeneratedWithConstantAndPropertyWithSameName(): void
     {
         $reflector      = new ClassReflection(TestAsset\TestSampleSingleClass::class);
@@ -863,9 +817,7 @@ CODE;
         self::assertSame($contents, $classGenerator->generate());
     }
 
-    /**
-     * @group 6253
-     */
+    #[Group('6253')]
     public function testHereDoc(): void
     {
         $reflector      = new ClassReflection(TestAsset\TestClassWithHeredoc::class);
@@ -1128,9 +1080,7 @@ CODE;
         self::assertCount(0, $overrides);
     }
 
-    /**
-     * @group generate
-     */
+    #[Group('generate')]
     public function testUseTraitGeneration(): void
     {
         $classGenerator = new ClassGenerator();
@@ -1149,9 +1099,7 @@ CODE;
         self::assertSame($output, $classGenerator->generate());
     }
 
-    /**
-     * @group generate
-     */
+    #[Group('generate')]
     public function testTraitGenerationWithAliasesAndOverrides(): void
     {
         $classGenerator = new ClassGenerator();
@@ -1222,9 +1170,7 @@ EOS;
         self::assertStringContainsString('class ClassName extends FooClass', $classGenerator->generate());
     }
 
-    /**
-     * @group 75
-     */
+    #[Group('75')]
     public function testCorrectlyExtendsFullyQualifiedParentClass(): void
     {
         $classGenerator = new ClassGenerator();
@@ -1234,9 +1180,7 @@ EOS;
         self::assertStringContainsString('class ClassName extends \DateTime', $classGenerator->generate());
     }
 
-    /**
-     * @group 75
-     */
+    #[Group('75')]
     public function testCorrectlyExtendsRelativeParentClass(): void
     {
         $classGenerator = new ClassGenerator();
@@ -1245,9 +1189,7 @@ EOS;
         self::assertStringContainsString('class ClassName extends DateTime', $classGenerator->generate());
     }
 
-    /**
-     * @group 75
-     */
+    #[Group('75')]
     public function testCorrectExtendNamesFromGlobalNamespace(): void
     {
         $classGenerator = new ClassGenerator();
@@ -1335,7 +1277,6 @@ EOS;
         self::assertStringContainsString($expected, $classGenerator->generate());
     }
 
-    /** @requires PHP >= 8.1 */
     public function testFinalConstantsAddedFromReflection(): void
     {
         $reflector      = new ClassReflection(TestAsset\ClassWithFinalConst::class);
@@ -1378,7 +1319,6 @@ EOS;
         self::assertSame($expectedOutput, $output, $output);
     }
 
-    /** @requires PHP >= 8.0 */
     public function testGenerateClassWithPromotedConstructorParameter(): void
     {
         $classGenerator = new ClassGenerator();
@@ -1405,7 +1345,6 @@ EOS;
         self::assertEquals($expectedOutput, $classGenerator->generate());
     }
 
-    /** @requires PHP >= 8.0 */
     public function testClassWithPromotedParameterFromReflection(): void
     {
         $classGenerator = ClassGenerator::fromReflection(
@@ -1427,7 +1366,6 @@ EOS;
         self::assertEquals($expectedOutput, $classGenerator->generate());
     }
 
-    /** @requires PHP >= 8.0 */
     public function testFailToGenerateClassWithPromotedParameterOnNonConstructorMethod(): void
     {
         $classGenerator = new ClassGenerator();
@@ -1442,7 +1380,7 @@ EOS;
         ]);
     }
 
-    /** @requires PHP >= 8.2 */
+    #[RequiresPhp('>= 8.2')]
     public function testReadonlyClassWithPromotedParameterFromReflection(): void
     {
         $classGenerator = ClassGenerator::fromReflection(
@@ -1464,7 +1402,7 @@ EOS;
         self::assertEquals($expectedOutput, $classGenerator->generate());
     }
 
-    /** @requires PHP >= 8.2 */
+    #[RequiresPhp('>= 8.2')]
     public function testDnfClass(): void
     {
         $classGenerator = ClassGenerator::fromReflection(

--- a/test/Generator/DocBlock/Tag/AuthorTagTest.php
+++ b/test/Generator/DocBlock/Tag/AuthorTagTest.php
@@ -5,12 +5,11 @@ namespace LaminasTest\Code\Generator\DocBlock\Tag;
 use Laminas\Code\Generator\DocBlock\Tag\AuthorTag;
 use Laminas\Code\Generator\DocBlock\TagManager;
 use Laminas\Code\Reflection\DocBlockReflection;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class AuthorTagTest extends TestCase
 {
     /** @var AuthorTag */

--- a/test/Generator/DocBlock/Tag/GenericTagTest.php
+++ b/test/Generator/DocBlock/Tag/GenericTagTest.php
@@ -5,12 +5,11 @@ namespace LaminasTest\Code\Generator\DocBlock\Tag;
 use Laminas\Code\Generator\DocBlock\Tag\GenericTag;
 use Laminas\Code\Generator\DocBlock\TagManager;
 use Laminas\Code\Reflection\DocBlockReflection;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class GenericTagTest extends TestCase
 {
     /** @var GenericTag */

--- a/test/Generator/DocBlock/Tag/LicenseTagTest.php
+++ b/test/Generator/DocBlock/Tag/LicenseTagTest.php
@@ -5,12 +5,11 @@ namespace LaminasTest\Code\Generator\DocBlock\Tag;
 use Laminas\Code\Generator\DocBlock\Tag\LicenseTag;
 use Laminas\Code\Generator\DocBlock\TagManager;
 use Laminas\Code\Reflection\DocBlockReflection;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class LicenseTagTest extends TestCase
 {
     /** @var LicenseTag */

--- a/test/Generator/DocBlock/Tag/MethodTagTest.php
+++ b/test/Generator/DocBlock/Tag/MethodTagTest.php
@@ -5,12 +5,11 @@ namespace LaminasTest\Code\Generator\DocBlock\Tag;
 use Laminas\Code\Generator\DocBlock\Tag\MethodTag;
 use Laminas\Code\Generator\DocBlock\TagManager;
 use Laminas\Code\Reflection\DocBlockReflection;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class MethodTagTest extends TestCase
 {
     /** @var MethodTag */

--- a/test/Generator/DocBlock/Tag/ParamTagTest.php
+++ b/test/Generator/DocBlock/Tag/ParamTagTest.php
@@ -5,12 +5,11 @@ namespace LaminasTest\Code\Generator\DocBlock\Tag;
 use Laminas\Code\Generator\DocBlock\Tag\ParamTag;
 use Laminas\Code\Generator\DocBlock\TagManager;
 use Laminas\Code\Reflection\DocBlockReflection;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class ParamTagTest extends TestCase
 {
     /** @var ParamTag */

--- a/test/Generator/DocBlock/Tag/PropertyTagTest.php
+++ b/test/Generator/DocBlock/Tag/PropertyTagTest.php
@@ -5,12 +5,11 @@ namespace LaminasTest\Code\Generator\DocBlock\Tag;
 use Laminas\Code\Generator\DocBlock\Tag\PropertyTag;
 use Laminas\Code\Generator\DocBlock\TagManager;
 use Laminas\Code\Reflection\DocBlockReflection;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class PropertyTagTest extends TestCase
 {
     /** @var PropertyTag */

--- a/test/Generator/DocBlock/Tag/ReturnTagTest.php
+++ b/test/Generator/DocBlock/Tag/ReturnTagTest.php
@@ -5,12 +5,11 @@ namespace LaminasTest\Code\Generator\DocBlock\Tag;
 use Laminas\Code\Generator\DocBlock\Tag\ReturnTag;
 use Laminas\Code\Generator\DocBlock\TagManager;
 use Laminas\Code\Reflection\DocBlockReflection;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class ReturnTagTest extends TestCase
 {
     /** @var ReturnTag */

--- a/test/Generator/DocBlock/Tag/ThrowsTagTest.php
+++ b/test/Generator/DocBlock/Tag/ThrowsTagTest.php
@@ -5,12 +5,11 @@ namespace LaminasTest\Code\Generator\DocBlock\Tag;
 use Laminas\Code\Generator\DocBlock\Tag\ThrowsTag;
 use Laminas\Code\Generator\DocBlock\TagManager;
 use Laminas\Code\Reflection\DocBlockReflection;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class ThrowsTagTest extends TestCase
 {
     /** @var ThrowsTag */

--- a/test/Generator/DocBlock/Tag/TypableTagTest.php
+++ b/test/Generator/DocBlock/Tag/TypableTagTest.php
@@ -3,12 +3,11 @@
 namespace LaminasTest\Code\Generator\DocBlock\Tag;
 
 use LaminasTest\Code\Generator\TestAsset\TypeableTag;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class TypableTagTest extends TestCase
 {
     /** @var TypeableTag */

--- a/test/Generator/DocBlock/Tag/VarTagTest.php
+++ b/test/Generator/DocBlock/Tag/VarTagTest.php
@@ -6,11 +6,10 @@ use Laminas\Code\Generator\DocBlock\Tag\VarTag;
 use Laminas\Code\Generator\DocBlock\TagManager;
 use Laminas\Code\Reflection\DocBlock\Tag\VarTag as ReflectionVarTag;
 use Laminas\Code\Reflection\DocBlockReflection;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Laminas\Code\Generator\DocBlock\Tag\VarTag
- */
+#[CoversClass(VarTag::class)]
 class VarTagTest extends TestCase
 {
     private VarTag $tag;

--- a/test/Generator/DocBlockGeneratorTest.php
+++ b/test/Generator/DocBlockGeneratorTest.php
@@ -9,12 +9,12 @@ use Laminas\Code\Generator\DocBlock\Tag\ParamTag;
 use Laminas\Code\Generator\DocBlock\Tag\ReturnTag;
 use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Reflection\DocBlockReflection;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group      Laminas_Code_Generator
- * @group      Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class DocBlockGeneratorTest extends TestCase
 {
     /** @var DocBlockGenerator */
@@ -116,9 +116,7 @@ EOS;
         self::assertCount(1, $docBlock->getTags());
     }
 
-    /**
-     * @group #3753
-     */
+    #[Group('#3753')]
     public function testGenerateWordWrapIsEnabledByDefault()
     {
         $largeStr = '@var This is a very large string that will be wrapped if it contains more than 80 characters';
@@ -131,9 +129,7 @@ EOS;
         self::assertSame($expected, $this->docBlockGenerator->generate());
     }
 
-    /**
-     * @group #3753
-     */
+    #[Group('#3753')]
     public function testGenerateWithWordWrapDisabled()
     {
         $largeStr = '@var This is a very large string that will not be wrapped if it contains more than 80 characters';
@@ -161,36 +157,28 @@ EOS;
         self::assertCount(4, $this->reflectionDocBlockGenerator->getTags());
     }
 
-    /**
-     * @depends testDocBlockFromReflectionTagsCount
-     */
+    #[Depends('testDocBlockFromReflectionTagsCount')]
     public function testDocBlockFromReflectionParamTag()
     {
         $tags = $this->reflectionDocBlockGenerator->getTags();
         self::assertInstanceOf(ParamTag::class, $tags[0]);
     }
 
-    /**
-     * @depends testDocBlockFromReflectionTagsCount
-     */
+    #[Depends('testDocBlockFromReflectionTagsCount')]
     public function testDocBlockFromReflectionAuthorTag()
     {
         $tags = $this->reflectionDocBlockGenerator->getTags();
         self::assertInstanceOf(AuthorTag::class, $tags[1]);
     }
 
-    /**
-     * @depends testDocBlockFromReflectionTagsCount
-     */
+    #[Depends('testDocBlockFromReflectionTagsCount')]
     public function testDocBlockFromReflectionLicenseTag()
     {
         $tags = $this->reflectionDocBlockGenerator->getTags();
         self::assertInstanceOf(LicenseTag::class, $tags[2]);
     }
 
-    /**
-     * @depends testDocBlockFromReflectionTagsCount
-     */
+    #[Depends('testDocBlockFromReflectionTagsCount')]
     public function testDocBlockFromReflectionReturnTag()
     {
         $tags = $this->reflectionDocBlockGenerator->getTags();

--- a/test/Generator/EnumGeneratorTest.php
+++ b/test/Generator/EnumGeneratorTest.php
@@ -4,6 +4,7 @@ namespace LaminasTest\Code\Generator;
 
 use InvalidArgumentException;
 use Laminas\Code\Generator\EnumGenerator\EnumGenerator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionEnum;
 
@@ -12,7 +13,6 @@ use function class_exists;
 final class EnumGeneratorTest extends TestCase
 {
     /**
-     * @dataProvider validOptionSpecifications
      * @psalm-param array{
      *      name: non-empty-string,
      *      pureCases: list<non-empty-string>,
@@ -24,6 +24,7 @@ final class EnumGeneratorTest extends TestCase
      *      },
      * } $options
      */
+    #[DataProvider('validOptionSpecifications')]
     public function testGenerateValidEnums(array $options, string $expected): void
     {
         self::assertSame($expected, EnumGenerator::withConfig($options)->generate());
@@ -123,22 +124,11 @@ final class EnumGeneratorTest extends TestCase
         ];
     }
 
-    /** @requires PHP < 8.1 */
-    public function testReflectionEnumFailsForUnsupportedPhpVersions(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('This feature only works from PHP 8.1 onwards.');
-
-        EnumGenerator::fromReflection(new ReflectionEnum(new class {
-        }));
-    }
-
     /**
-     * @requires PHP >= 8.1
-     * @dataProvider validEnumSpecifications
      * @psalm-param non-empty-string $enumClass
      * @psalm-param non-empty-string $expected
      */
+    #[DataProvider('validEnumSpecifications')]
     public function testReflectionEnumWorks(string $enumClass, string $expected): void
     {
         if (! class_exists($enumClass, false)) {

--- a/test/Generator/FileGeneratorTest.php
+++ b/test/Generator/FileGeneratorTest.php
@@ -7,6 +7,7 @@ use Laminas\Code\Exception\InvalidArgumentException;
 use Laminas\Code\Generator\ClassGenerator;
 use Laminas\Code\Generator\Exception\ClassNotFoundException;
 use Laminas\Code\Generator\FileGenerator;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -18,17 +19,15 @@ use function strpos;
 use function strrpos;
 use function sys_get_temp_dir;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- * @group Laminas_Code_Generator_Php_File
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
+#[Group('Laminas_Code_Generator_Php_File')]
 class FileGeneratorTest extends TestCase
 {
     public function testConstruction()
     {
         $file = new FileGenerator();
-        self::assertSame(FileGenerator::class, get_class($file));
+        self::assertSame(FileGenerator::class, $file::class);
     }
 
     public function testSourceContentGetterAndSetter()
@@ -86,9 +85,7 @@ EOS;
         $fileGenerator->getClass('TestClass');
     }
 
-    /**
-     * @group test
-     */
+    #[Group('test')]
     public function testFileLineEndingsAreAlwaysLineFeed()
     {
         $codeGenFile = FileGenerator::fromArray([
@@ -109,9 +106,7 @@ EOS;
         self::assertSame(';', $lines[2][$targetLength - 1]);
     }
 
-    /**
-     * @group Laminas-11218
-     */
+    #[Group('Laminas-11218')]
     public function testGeneratesUseStatements()
     {
         $file = new FileGenerator();
@@ -358,7 +353,7 @@ EOS;
         $generator->setDeclares([new stdClass()]);
     }
 
-    /** @group gh-42 */
+    #[Group('gh-42')]
     public function testDeclareStatementsArePutBeforeNamespace(): void
     {
         $generator = new FileGenerator();

--- a/test/Generator/InterfaceGeneratorTest.php
+++ b/test/Generator/InterfaceGeneratorTest.php
@@ -12,12 +12,11 @@ use Laminas\Code\Generator\MethodGenerator;
 use Laminas\Code\Generator\PropertyGenerator;
 use Laminas\Code\Reflection\ClassReflection;
 use LaminasTest\Code\TestAsset\FooInterface;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class InterfaceGeneratorTest extends TestCase
 {
     public function testAbstractAccessorsReturnsFalse()
@@ -125,9 +124,7 @@ CODE;
         self::assertSame($expected, $classGeneratorClass->generate());
     }
 
-    /**
-     * @group namespace
-     */
+    #[Group('namespace')]
     public function testCodeGenerationShouldTakeIntoAccountNamespacesFromReflection()
     {
         $reflClass      = new ClassReflection(FooInterface::class);
@@ -152,9 +149,7 @@ CODE;
         self::assertSame($expected, $received, $received);
     }
 
-    /**
-     * @group namespace
-     */
+    #[Group('namespace')]
     public function testSetNameShouldDetermineIfNamespaceSegmentIsPresent()
     {
         $classGeneratorClass = new InterfaceGenerator();
@@ -162,9 +157,7 @@ CODE;
         self::assertSame('My\Namespaced', $classGeneratorClass->getNamespaceName());
     }
 
-    /**
-     * @group namespace
-     */
+    #[Group('namespace')]
     public function testPassingANamespacedClassnameShouldGenerateANamespaceDeclaration()
     {
         $classGeneratorClass = new InterfaceGenerator();
@@ -173,9 +166,7 @@ CODE;
         self::assertStringContainsString('namespace My\Namespaced;', $received, $received);
     }
 
-    /**
-     * @group namespace
-     */
+    #[Group('namespace')]
     public function testPassingANamespacedClassnameShouldGenerateAClassnameWithoutItsNamespace()
     {
         $classGeneratorClass = new InterfaceGenerator();

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -17,6 +17,8 @@ use LaminasTest\Code\TestAsset\NullableReturnTypeHintedClass;
 use LaminasTest\Code\TestAsset\ObjectHintsClass;
 use LaminasTest\Code\TestAsset\Php80Types;
 use LaminasTest\Code\TestAsset\ReturnTypeHintedClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -25,10 +27,8 @@ use function array_map;
 use function array_shift;
 use function array_values;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class MethodGeneratorTest extends TestCase
 {
     public function testMethodConstructor()
@@ -135,7 +135,6 @@ EOS;
         self::assertSame($target, (string) $methodGenerator);
     }
 
-    /** @requires PHP >= 8.0 */
     public function testCopyMethodSignatureForPromotedParameter(): void
     {
         $ref = new MethodReflection(TestAsset\ClassWithPromotedParameter::class, '__construct');
@@ -194,9 +193,7 @@ EOS;
         self::assertSame($target, (string) $methodGenerator);
     }
 
-    /**
-     * @group Laminas-6444
-     */
+    #[Group('Laminas-6444')]
     public function testMethodWithStaticModifierIsEmitted()
     {
         $methodGenerator = new MethodGenerator();
@@ -214,9 +211,7 @@ EOS;
         self::assertSame($expected, $methodGenerator->generate());
     }
 
-    /**
-     * @group Laminas-6444
-     */
+    #[Group('Laminas-6444')]
     public function testMethodWithFinalModifierIsEmitted()
     {
         $methodGenerator = new MethodGenerator();
@@ -233,9 +228,7 @@ EOS;
         self::assertSame($expected, $methodGenerator->generate());
     }
 
-    /**
-     * @group Laminas-6444
-     */
+    #[Group('Laminas-6444')]
     public function testMethodWithFinalModifierIsNotEmittedWhenMethodIsAbstract()
     {
         $methodGenerator = new MethodGenerator();
@@ -250,9 +243,7 @@ EOS;
         self::assertSame($expected, $methodGenerator->generate());
     }
 
-    /**
-     * @group Laminas-7205
-     */
+    #[Group('Laminas-7205')]
     public function testMethodCanHaveDocBlock()
     {
         $methodGeneratorProperty = new MethodGenerator(
@@ -275,9 +266,7 @@ EOS;
         self::assertSame($expected, $methodGeneratorProperty->generate());
     }
 
-    /**
-     * @group Laminas-7268
-     */
+    #[Group('Laminas-7268')]
     public function testDefaultValueGenerationDoesNotIncludeTrailingSemicolon()
     {
         $method  = new MethodGenerator('setOptions');
@@ -319,11 +308,10 @@ EOS;
     }
 
     /**
-     * @dataProvider returnsReferenceValues
-     * @param bool|string|int $value
      * @param bool $expected
      */
-    public function testCreateFromArrayWithReturnsReference($value, $expected): void
+    #[DataProvider('returnsReferenceValues')]
+    public function testCreateFromArrayWithReturnsReference(bool|string|int $value, $expected): void
     {
         $methodGenerator = MethodGenerator::fromArray([
             'name'             => 'SampleMethod',
@@ -376,9 +364,7 @@ CODE;
         self::assertInstanceOf(DocBlockGenerator::class, $methodGenerator->getDocBlock());
     }
 
-    /**
-     * @group zendframework/zend-code#29
-     */
+    #[Group('zendframework/zend-code#29')]
     public function testSetReturnType()
     {
         $methodGenerator = new MethodGenerator();
@@ -395,9 +381,7 @@ PHP;
         self::assertSame($expected, $methodGenerator->generate());
     }
 
-    /**
-     * @group zendframework/zend-code#29
-     */
+    #[Group('zendframework/zend-code#29')]
     public function testSetReturnTypeWithNull()
     {
         $methodGenerator = new MethodGenerator();
@@ -415,12 +399,12 @@ PHP;
     }
 
     /**
-     * @group zendframework/zend-code#29
-     * @dataProvider returnTypeHintClasses
      * @param string $className
      * @param string $methodName
      * @param string $expectedReturnSignature
      */
+    #[DataProvider('returnTypeHintClasses')]
+    #[Group('zendframework/zend-code#29')]
     public function testFrom($className, $methodName, $expectedReturnSignature)
     {
         $methodGenerator = MethodGenerator::fromReflection(new MethodReflection($className, $methodName));
@@ -470,9 +454,7 @@ PHP;
         ];
     }
 
-    /**
-     * @group zendframework/zend-code#29
-     */
+    #[Group('zendframework/zend-code#29')]
     public function testByRefReturnType()
     {
         $methodGenerator = new MethodGenerator('foo');
@@ -486,9 +468,7 @@ PHP;
         self::assertStringMatchesFormat('%Apublic function foo()%A', $methodGenerator->generate());
     }
 
-    /**
-     * @group zendframework/zend-code#29
-     */
+    #[Group('zendframework/zend-code#29')]
     public function testFromByReferenceMethodReflection()
     {
         $methodGenerator = MethodGenerator::fromReflection(
@@ -499,13 +479,12 @@ PHP;
     }
 
     /**
-     * @requires PHP >= 8.0
-     * @group laminas/laminas-code#53
-     * @dataProvider php80Methods
      * @psalm-param class-string $className
      * @psalm-param non-empty-string $method
      * @psalm-param non-empty-string $expectedGeneratedSignature
      */
+    #[DataProvider('php80Methods')]
+    #[Group('laminas/laminas-code#53')]
     public function testGeneratedReturnTypeForPhp80ReturnType(
         string $className,
         string $method,

--- a/test/Generator/ParameterGeneratorTest.php
+++ b/test/Generator/ParameterGeneratorTest.php
@@ -20,7 +20,11 @@ use LaminasTest\Code\TestAsset\NullNullableDefaultHintsClass;
 use LaminasTest\Code\TestAsset\ObjectHintsClass;
 use LaminasTest\Code\TestAsset\Php80Types;
 use LaminasTest\Code\TestAsset\VariadicParametersClass;
+use Namespaced\TypeHint\Bar;
 use Phar;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use stdClass;
@@ -33,10 +37,8 @@ use function ltrim;
 use function strpos;
 use function strtolower;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class ParameterGeneratorTest extends TestCase
 {
     public function testTypeGetterAndSetterPersistValue()
@@ -114,24 +116,6 @@ class ParameterGeneratorTest extends TestCase
         self::assertSame('\'foo\'', (string) $defaultValue);
     }
 
-    /**
-     * @group 95
-     * @requires PHP < 8.1
-     */
-    public function testFromReflectionGetDefaultValueNotOptional()
-    {
-        $method = new MethodReflection(ParameterClass::class, 'defaultObjectEqualsNullAndNotOptional');
-
-        $params = $method->getParameters();
-
-        self::assertCount(2, $params);
-
-        $firstParameter = ParameterGenerator::fromReflection($params[0]);
-        $valueGenerator = $firstParameter->getDefaultValue();
-        self::assertInstanceOf(ValueGenerator::class, $valueGenerator);
-        self::assertNull($valueGenerator->getSourceContent());
-    }
-
     public function testFromReflectionGetArrayHint()
     {
         $reflectionParameter = $this->getFirstReflectionParameter('fromArray');
@@ -159,10 +143,10 @@ class ParameterGeneratorTest extends TestCase
     }
 
     /**
-     * @dataProvider dataFromReflectionGenerate
      * @param string $methodName
      * @param string $expectedCode
      */
+    #[DataProvider('dataFromReflectionGenerate')]
     public function testFromReflectionGenerate($methodName, $expectedCode)
     {
         $reflectionParameter = $this->getFirstReflectionParameter($methodName);
@@ -241,9 +225,7 @@ class ParameterGeneratorTest extends TestCase
         self::assertTrue($reflectionOmitDefaultValue->getValue($parameterGenerator));
     }
 
-    /**
-     * @group 4988
-     */
+    #[Group('4988')]
     public function testParameterGeneratorReturnsCorrectTypeForNonNamespaceClasses()
     {
         require_once __DIR__ . '/../TestAsset/NonNamespaceClass.php';
@@ -256,25 +238,21 @@ class ParameterGeneratorTest extends TestCase
         self::assertSame('LaminasTest_Code_NsTest_BarClass', $param->getType());
     }
 
-    /**
-     * @group 5193
-     */
+    #[Group('5193')]
     public function testTypehintsWithNamespaceInNamepsacedClassReturnTypewithBackslash()
     {
         require_once __DIR__ . '/TestAsset/NamespaceTypeHintClass.php';
 
-        $reflClass = new ClassReflection('Namespaced\TypeHint\Bar');
+        $reflClass = new ClassReflection(Bar::class);
         $params    = $reflClass->getMethod('method')->getParameters();
 
         $param = ParameterGenerator::fromReflection($params[0]);
 
-        self::assertSame('OtherNamespace\ParameterClass', $param->getType());
+        self::assertSame(\OtherNamespace\ParameterClass::class, $param->getType());
     }
 
-    /**
-     * @group 6023
-     * @coversNothing
-     */
+    #[Group('6023')]
+    #[CoversNothing]
     public function testGeneratedParametersHaveEscapedDefaultValues()
     {
         $parameter = new ParameterGenerator();
@@ -287,11 +265,11 @@ class ParameterGeneratorTest extends TestCase
     }
 
     /**
-     * @group zendframework/zend-code#29
-     * @dataProvider simpleHints
      * @param string $type
      * @param string $expectedType
      */
+    #[DataProvider('simpleHints')]
+    #[Group('zendframework/zend-code#29')]
     public function testGeneratesSimpleHints($type, $expectedType)
     {
         $parameter = new ParameterGenerator();
@@ -330,10 +308,10 @@ class ParameterGeneratorTest extends TestCase
     }
 
     /**
-     * @group zendframework/zend-code#29
-     * @dataProvider validClassName
      * @param string $className
      */
+    #[DataProvider('validClassName')]
+    #[Group('zendframework/zend-code#29')]
     public function testTypeHintWithValidClassName($className)
     {
         $parameter = new ParameterGenerator();
@@ -366,13 +344,13 @@ class ParameterGeneratorTest extends TestCase
     }
 
     /**
-     * @group zendframework/zend-code#29
-     * @dataProvider reflectionHints
      * @param string      $className
      * @param string      $methodName
      * @param string      $parameterName
      * @param string|null $expectedType
      */
+    #[DataProvider('reflectionHints')]
+    #[Group('zendframework/zend-code#29')]
     public function testTypeHintFromReflection($className, $methodName, $parameterName, $expectedType)
     {
         $parameter = ParameterGenerator::fromReflection(new ParameterReflection(
@@ -390,13 +368,13 @@ class ParameterGeneratorTest extends TestCase
     }
 
     /**
-     * @group zendframework/zend-code#29
-     * @dataProvider reflectionHints
      * @param string      $className
      * @param string      $methodName
      * @param string      $parameterName
      * @param string|null $expectedType
      */
+    #[DataProvider('reflectionHints')]
+    #[Group('zendframework/zend-code#29')]
     public function testTypeHintFromReflectionGeneratedCode($className, $methodName, $parameterName, $expectedType)
     {
         $parameter = ParameterGenerator::fromReflection(new ParameterReflection(
@@ -487,13 +465,13 @@ class ParameterGeneratorTest extends TestCase
     }
 
     /**
-     * @group zendframework/zend-code#29
-     * @dataProvider variadicHints
      * @param string $className
      * @param string $methodName
      * @param string $parameterName
      * @param string $expectedGeneratedSignature
      */
+    #[DataProvider('variadicHints')]
+    #[Group('zendframework/zend-code#29')]
     public function testVariadicArgumentFromReflection(
         $className,
         $methodName,
@@ -538,9 +516,7 @@ class ParameterGeneratorTest extends TestCase
         ];
     }
 
-    /**
-     * @group zendframework/zend-code#29
-     */
+    #[Group('zendframework/zend-code#29')]
     public function testSetGetVariadic()
     {
         $parameter = new ParameterGenerator('foo');
@@ -590,9 +566,7 @@ class ParameterGeneratorTest extends TestCase
         $parameter->setVariadic(true);
     }
 
-    /**
-     * @group zendframework/zend-code#29
-     */
+    #[Group('zendframework/zend-code#29')]
     public function testGetInternalClassDefaultParameterValue()
     {
         $parameter = ParameterGenerator::fromReflection(new ParameterReflection([Phar::class, 'compress'], 1));
@@ -601,14 +575,13 @@ class ParameterGeneratorTest extends TestCase
     }
 
     /**
-     * @requires PHP >= 8.0
-     * @group laminas/laminas-code#53
-     * @dataProvider php80Methods
      * @psalm-param class-string $className
      * @psalm-param non-empty-string $method
      * @psalm-param positive-int|0 $parameterIndex
      * @psalm-param non-empty-string $expectedGeneratedSignature
      */
+    #[DataProvider('php80Methods')]
+    #[Group('laminas/laminas-code#53')]
     public function testGeneratedSignatureForPhp80ParameterType(
         string $className,
         string $method,

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -14,6 +14,8 @@ use Laminas\Code\Generator\ValueGenerator;
 use Laminas\Code\Reflection\ClassReflection;
 use Laminas\Code\Reflection\PropertyReflection;
 use LaminasTest\Code\Generator\TestAsset\ClassWithTypedProperty;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use stdClass;
@@ -23,10 +25,8 @@ use function array_shift;
 use function str_replace;
 use function uniqid;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class PropertyGeneratorTest extends TestCase
 {
     public function testPropertyConstructor(): void
@@ -55,11 +55,8 @@ class PropertyGeneratorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataSetTypeSetValueGenerate
-     * @param  mixed  $value
-     */
-    public function testSetTypeSetValueGenerate(string $type, $value, string $code): void
+    #[DataProvider('dataSetTypeSetValueGenerate')]
+    public function testSetTypeSetValueGenerate(string $type, mixed $value, string $code): void
     {
         $defaultValue = new PropertyValueGenerator();
         $defaultValue->setType($type);
@@ -69,11 +66,8 @@ class PropertyGeneratorTest extends TestCase
         self::assertSame($code, $defaultValue->generate());
     }
 
-    /**
-     * @dataProvider dataSetTypeSetValueGenerate
-     * @param  mixed  $value
-     */
-    public function testSetBogusTypeSetValueGenerateUseAutoDetection(string $type, $value, string $code): void
+    #[DataProvider('dataSetTypeSetValueGenerate')]
+    public function testSetBogusTypeSetValueGenerateUseAutoDetection(string $type, mixed $value, string $code): void
     {
         if ('constant' === $type) {
             self::markTestSkipped('constant can only be detected explicitly');
@@ -129,9 +123,7 @@ EOS;
         yield 'private' => [PropertyGenerator::FLAG_PRIVATE, 'private'];
     }
 
-    /**
-     * @dataProvider visibility
-     */
+    #[DataProvider('visibility')]
     public function testPropertyCanProduceConstantWithVisibility(int $flag, string $visibility): void
     {
         $codeGenProperty = new PropertyGenerator('FOO', 'bar', [PropertyGenerator::FLAG_CONSTANT, $flag]);
@@ -154,9 +146,7 @@ EOS;
         self::assertSame('    final public const someVal = \'some string value\';', $codeGenProperty->generate());
     }
 
-    /**
-     * @dataProvider visibility
-     */
+    #[DataProvider('visibility')]
     public function testPropertyCanProduceReadonlyModifier(int $flag, string $visibility): void
     {
         $codeGenProperty = new PropertyGenerator(
@@ -191,9 +181,7 @@ EOS;
         $codeGenProperty->setFlags(PropertyGenerator::FLAG_READONLY | PropertyGenerator::FLAG_CONSTANT);
     }
 
-    /**
-     * @group PR-704
-     */
+    #[Group('PR-704')]
     public function testPropertyCanProduceConstantModifierWithSetter(): void
     {
         $codeGenProperty = new PropertyGenerator('someVal', 'some string value');
@@ -207,9 +195,7 @@ EOS;
         self::assertSame('    public static $someVal = \'some string value\';', $codeGenProperty->generate());
     }
 
-    /**
-     * @group Laminas-6444
-     */
+    #[Group('Laminas-6444')]
     public function testPropertyWillLoadFromReflection(): void
     {
         $reflectionClass = new ClassReflection(TestAsset\TestClassWithManyProperties::class);
@@ -238,9 +224,7 @@ EOS;
         self::assertSame('private', $cgProp->getVisibility());
     }
 
-    /**
-     * @group Laminas-6444
-     */
+    #[Group('Laminas-6444')]
     public function testPropertyWillEmitStaticModifier(): void
     {
         $codeGenProperty = new PropertyGenerator(
@@ -251,9 +235,7 @@ EOS;
         self::assertSame('    protected static $someVal = \'some string value\';', $codeGenProperty->generate());
     }
 
-    /**
-     * @group Laminas-7205
-     */
+    #[Group('Laminas-7205')]
     public function testPropertyCanHaveDocBlock(): void
     {
         $codeGenProperty = new PropertyGenerator(
@@ -335,9 +317,7 @@ EOS;
         self::assertSame(PropertyGenerator::VISIBILITY_PUBLIC, $propertyGenerator->getVisibility());
     }
 
-    /**
-     * @group 3491
-     */
+    #[Group('3491')]
     public function testPropertyDocBlockWillLoadFromReflection(): void
     {
         $reflectionClass = new ClassReflection(TestAsset\TestClassWithManyProperties::class);
@@ -357,11 +337,8 @@ EOS;
         self::assertSame('var', $tag->getName());
     }
 
-    /**
-     * @dataProvider dataSetTypeSetValueGenerate
-     * @param  mixed  $value
-     */
-    public function testSetDefaultValue(string $type, $value): void
+    #[DataProvider('dataSetTypeSetValueGenerate')]
+    public function testSetDefaultValue(string $type, mixed $value): void
     {
         $property = new PropertyGenerator();
         $property->setDefaultValue($value, $type);
@@ -401,7 +378,6 @@ EOS;
         self::assertSame('    private string $typedProperty;', $code);
     }
 
-    /** @requires PHP >= 8.1 */
     public function testFromReflectionReadonlyProperty(): void
     {
         $className = uniqid('ClassWithReadonlyProperty', false);

--- a/test/Generator/PropertyValueGeneratorTest.php
+++ b/test/Generator/PropertyValueGeneratorTest.php
@@ -3,12 +3,11 @@
 namespace LaminasTest\Code\Generator;
 
 use Laminas\Code\Generator\PropertyValueGenerator;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class PropertyValueGeneratorTest extends TestCase
 {
     public function testPropertyValueAddsSemicolonToValueGenerator()

--- a/test/Generator/TraitGeneratorTest.php
+++ b/test/Generator/TraitGeneratorTest.php
@@ -13,6 +13,7 @@ use Laminas\Code\Generator\PropertyGenerator;
 use Laminas\Code\Generator\TraitGenerator;
 use Laminas\Code\Reflection\ClassReflection;
 use LaminasTest\Code\Generator\TestAsset\PrototypeClass;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionException;
@@ -21,10 +22,8 @@ use Throwable;
 
 use function current;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class TraitGeneratorTest extends TestCase
 {
     public function testConstruction(): void
@@ -193,9 +192,7 @@ class TraitGeneratorTest extends TestCase
         $classGenerator->addMethodFromGenerator($methodB);
     }
 
-    /**
-     * @group Laminas-7361
-     */
+    #[Group('Laminas-7361')]
     public function testHasMethod(): void
     {
         $classGenerator = new TraitGenerator();
@@ -214,9 +211,7 @@ class TraitGeneratorTest extends TestCase
         self::assertFalse($classGenerator->hasMethod('methodOne'));
     }
 
-    /**
-     * @group Laminas-7361
-     */
+    #[Group('Laminas-7361')]
     public function testHasProperty(): void
     {
         $classGenerator = new TraitGenerator();
@@ -256,9 +251,7 @@ EOS;
         self::assertSame($expectedOutput, $output, $output);
     }
 
-    /**
-     * @group Laminas-7909
-     */
+    #[Group('Laminas-7909')]
     public function testClassFromReflectionThatImplementsInterfaces(): void
     {
         $reflClass = new ClassReflection(TestAsset\ClassWithInterface::class);
@@ -272,9 +265,7 @@ EOS;
         self::assertStringContainsString($expectedClassDef, $code);
     }
 
-    /**
-     * @group Laminas-7909
-     */
+    #[Group('Laminas-7909')]
     public function testClassFromReflectionDiscardParentImplementedInterfaces(): void
     {
         $reflClass = new ClassReflection(TestAsset\NewClassWithInterface::class);
@@ -288,9 +279,7 @@ EOS;
         self::assertStringContainsString($expectedClassDef, $code);
     }
 
-    /**
-     * @group 4988
-     */
+    #[Group('4988')]
     public function testNonNamespaceClassReturnsAllMethods(): void
     {
         require_once __DIR__ . '/../TestAsset/NonNamespaceClass.php';
@@ -308,9 +297,7 @@ EOS;
         self::assertCount(1, $classGenerator->getMethods());
     }
 
-    /**
-     * @group Laminas-9602
-     */
+    #[Group('Laminas-9602')]
     public function testSetextendedclassShouldIgnoreEmptyClassnameOnGenerate(): void
     {
         $classGeneratorClass = new TraitGenerator();
@@ -327,9 +314,7 @@ CODE;
         self::assertSame($expected, $classGeneratorClass->generate());
     }
 
-    /**
-     * @group Laminas-9602
-     */
+    #[Group('Laminas-9602')]
     public function testSetextendedclassShouldNotIgnoreNonEmptyClassnameOnGenerate(): void
     {
         $classGeneratorClass = new TraitGenerator();
@@ -346,9 +331,7 @@ CODE;
         self::assertSame($expected, $classGeneratorClass->generate());
     }
 
-    /**
-     * @group namespace
-     */
+    #[Group('namespace')]
     public function testCodeGenerationShouldTakeIntoAccountNamespacesFromReflection(): void
     {
         $reflClass      = new ClassReflection(TestAsset\ClassWithNamespace::class);
@@ -367,9 +350,7 @@ CODE;
         self::assertSame($expected, $received, $received);
     }
 
-    /**
-     * @group namespace
-     */
+    #[Group('namespace')]
     public function testSetNameShouldDetermineIfNamespaceSegmentIsPresent(): void
     {
         $classGeneratorClass = new TraitGenerator();
@@ -377,9 +358,7 @@ CODE;
         self::assertSame('My\Namespaced', $classGeneratorClass->getNamespaceName());
     }
 
-    /**
-     * @group namespace
-     */
+    #[Group('namespace')]
     public function testPassingANamespacedClassnameShouldGenerateANamespaceDeclaration(): void
     {
         $classGeneratorClass = new TraitGenerator();
@@ -388,9 +367,7 @@ CODE;
         self::assertStringContainsString('namespace My\Namespaced;', $received, $received);
     }
 
-    /**
-     * @group namespace
-     */
+    #[Group('namespace')]
     public function testPassingANamespacedClassnameShouldGenerateAClassnameWithoutItsNamespace(): void
     {
         $classGeneratorClass = new TraitGenerator();
@@ -399,9 +376,7 @@ CODE;
         self::assertStringContainsString('trait FunClass', $received, $received);
     }
 
-    /**
-     * @group Laminas-151
-     */
+    #[Group('Laminas-151')]
     public function testAddUses(): void
     {
         $classGenerator = new TraitGenerator();
@@ -414,9 +389,7 @@ CODE;
         self::assertStringContainsString('use My\Second\Use\Class as MyAlias;', $generated);
     }
 
-    /**
-     * @group 4990
-     */
+    #[Group('4990')]
     public function testAddOneUseTwiceOnlyAddsOne(): void
     {
         $classGenerator = new TraitGenerator();
@@ -430,9 +403,7 @@ CODE;
         self::assertStringContainsString('use My\First\Use\Class;', $generated);
     }
 
-    /**
-     * @group 4990
-     */
+    #[Group('4990')]
     public function testAddOneUseWithAliasTwiceOnlyAddsOne(): void
     {
         $classGenerator = new TraitGenerator();

--- a/test/Generator/TypeGenerator/CompositeTypeTest.php
+++ b/test/Generator/TypeGenerator/CompositeTypeTest.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace LaminasTest\Code\Generator\TypeGenerator;
 
 use Laminas\Code\Generator\TypeGenerator\CompositeType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-/** @covers \Laminas\Code\Generator\TypeGenerator\CompositeType */
+#[CoversClass(CompositeType::class)]
 class CompositeTypeTest extends TestCase
 {
-    /**
-     * @dataProvider validType
-     */
+    #[DataProvider('validType')]
     public function testFromValidTypeString(string $typeString, string $expectedReturnType): void
     {
         $type = CompositeType::fromString($typeString);

--- a/test/Generator/TypeGenerator/IntersectionTypeTest.php
+++ b/test/Generator/TypeGenerator/IntersectionTypeTest.php
@@ -7,16 +7,18 @@ namespace LaminasTest\Code\Generator\TypeGenerator;
 use Laminas\Code\Generator\Exception\InvalidArgumentException;
 use Laminas\Code\Generator\TypeGenerator\AtomicType;
 use Laminas\Code\Generator\TypeGenerator\IntersectionType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-/** @covers \Laminas\Code\Generator\TypeGenerator\IntersectionType */
+#[CoversClass(IntersectionType::class)]
 class IntersectionTypeTest extends TestCase
 {
     /**
-     * @dataProvider sortingExamples
      * @param non-empty-list<AtomicType> $types
      * @param non-empty-string           $expected
      */
+    #[DataProvider('sortingExamples')]
     public function testTypeSorting(array $types, string $expected): void
     {
         self::assertSame(
@@ -58,9 +60,9 @@ class IntersectionTypeTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidIntersectionsExamples
      * @param non-empty-list<AtomicType> $types
      */
+    #[DataProvider('invalidIntersectionsExamples')]
     public function testWillRejectInvalidIntersections(array $types): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/test/Generator/TypeGenerator/UnionTypeTest.php
+++ b/test/Generator/TypeGenerator/UnionTypeTest.php
@@ -8,16 +8,18 @@ use Laminas\Code\Generator\Exception\InvalidArgumentException;
 use Laminas\Code\Generator\TypeGenerator\AtomicType;
 use Laminas\Code\Generator\TypeGenerator\IntersectionType;
 use Laminas\Code\Generator\TypeGenerator\UnionType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-/** @covers \Laminas\Code\Generator\TypeGenerator\UnionType */
+#[CoversClass(UnionType::class)]
 class UnionTypeTest extends TestCase
 {
     /**
-     * @dataProvider sortingExamples
      * @param non-empty-list<AtomicType|IntersectionType> $types
      * @param non-empty-string                            $expected
      */
+    #[DataProvider('sortingExamples')]
     public function testTypeSorting(array $types, string $expected): void
     {
         self::assertSame(
@@ -95,9 +97,9 @@ class UnionTypeTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidUnionsExamples
      * @param non-empty-list<AtomicType|IntersectionType> $types
      */
+    #[DataProvider('invalidUnionsExamples')]
     public function testWillRejectInvalidUnions(array $types): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/test/Generator/TypeGeneratorTest.php
+++ b/test/Generator/TypeGeneratorTest.php
@@ -5,6 +5,10 @@ namespace LaminasTest\Code\Generator;
 use Laminas\Code\Exception\InvalidArgumentException;
 use Laminas\Code\Generator\GeneratorInterface;
 use Laminas\Code\Generator\TypeGenerator;
+use Laminas\Code\Generator\TypeGenerator\AtomicType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_combine;
@@ -16,11 +20,9 @@ use function str_replace;
 use function str_starts_with;
 use function strpos;
 
-/**
- * @group zendframework/zend-code#29
- * @covers \Laminas\Code\Generator\TypeGenerator
- * @covers \Laminas\Code\Generator\TypeGenerator\AtomicType
- */
+#[Group('zendframework/zend-code#29')]
+#[CoversClass(TypeGenerator::class)]
+#[CoversClass(AtomicType::class)]
 class TypeGeneratorTest extends TestCase
 {
     public function testIsAGenerator()
@@ -28,24 +30,16 @@ class TypeGeneratorTest extends TestCase
         self::assertContains(GeneratorInterface::class, class_implements(TypeGenerator::class));
     }
 
-    /**
-     * @dataProvider validType
-     * @param string $typeString
-     * @param string $expectedReturnType
-     */
-    public function testFromValidTypeString($typeString, $expectedReturnType)
+    #[DataProvider('validType')]
+    public function testFromValidTypeString(string $typeString, string $expectedReturnType): void
     {
         $generator = TypeGenerator::fromTypeString($typeString);
 
         self::assertSame($expectedReturnType, $generator->generate());
     }
 
-    /**
-     * @dataProvider validType
-     * @param string $typeString
-     * @param string $expectedReturnType
-     */
-    public function testStringCastFromValidTypeString($typeString, $expectedReturnType)
+    #[DataProvider('validType')]
+    public function testStringCastFromValidTypeString(string $typeString, string $expectedReturnType): void
     {
         $generator = TypeGenerator::fromTypeString($typeString);
 
@@ -55,11 +49,8 @@ class TypeGeneratorTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider invalidType
-     * @param string $typeString
-     */
-    public function testRejectsInvalidTypeString($typeString)
+    #[DataProvider('invalidType')]
+    public function testRejectsInvalidTypeString(string $typeString): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -13,17 +13,18 @@ use Laminas\Code\Generator\PropertyValueGenerator;
 use Laminas\Code\Generator\ValueGenerator;
 use Laminas\Stdlib\ArrayObject as StdlibArrayObject;
 use LaminasTest\Code\Generator\TestAsset\TestEnum;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function fopen;
 use function sprintf;
 use function str_replace;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- * @covers \Laminas\Code\Generator\ValueGenerator
- */
+#[CoversClass(ValueGenerator::class)]
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class ValueGeneratorTest extends TestCase
 {
     public function testDefaultInstance(): void
@@ -42,11 +43,8 @@ class ValueGeneratorTest extends TestCase
         new ValueGenerator(null, ValueGenerator::TYPE_AUTO, ValueGenerator::OUTPUT_MULTIPLE_LINE, $constants);
     }
 
-    /**
-     * @dataProvider constantsType
-     * @param SplArrayObject|StdlibArrayObject $constants
-     */
-    public function testAllowedPossibleConstantsType($constants): void
+    #[DataProvider('constantsType')]
+    public function testAllowedPossibleConstantsType(SplArrayObject|StdlibArrayObject $constants): void
     {
         $valueGenerator = new ValueGenerator(
             null,
@@ -71,10 +69,10 @@ class ValueGeneratorTest extends TestCase
     }
 
     /**
-     * @group #94
-     * @dataProvider validConstantTypes
      * @param string $expectedOutput
      */
+    #[DataProvider('validConstantTypes')]
+    #[Group('#94')]
     public function testValidConstantTypes(PropertyValueGenerator $generator, $expectedOutput): void
     {
         $propertyGenerator = new PropertyGenerator('FOO', $generator);
@@ -83,7 +81,6 @@ class ValueGeneratorTest extends TestCase
     }
 
     /**
-     * @return array
      * @psalm-return non-empty-list<array{PropertyValueGenerator, non-empty-string}>
      */
     public static function validConstantTypes(): array
@@ -126,7 +123,6 @@ class ValueGeneratorTest extends TestCase
 
     /**
      * @param string $longOutput
-     * @param array $value
      * @return array
      */
     protected static function generateArrayData($longOutput, array $value)
@@ -336,11 +332,10 @@ EOS;
     }
 
     /**
-     * @dataProvider unsortedKeysArray
      * @param string $type
-     * @param array $value
      * @param string $expected
      */
+    #[DataProvider('unsortedKeysArray')]
     public function testPropertyDefaultValueCanHandleArrayWithUnsortedKeys($type, array $value, $expected)
     {
         $valueGenerator = new ValueGenerator();
@@ -405,11 +400,10 @@ EOS;
     }
 
     /**
-     * @dataProvider simpleArray
      * @param string $type
-     * @param array $value
      * @param string $expected
      */
+    #[DataProvider('simpleArray')]
     public function testPropertyDefaultValueCanHandleArray($type, array $value, $expected)
     {
         $valueGenerator = new ValueGenerator();
@@ -436,11 +430,10 @@ EOS;
     }
 
     /**
-     * @dataProvider complexArray
      * @param string $type
-     * @param array $value
      * @param string $expected
      */
+    #[DataProvider('complexArray')]
     public function testPropertyDefaultValueCanHandleComplexArrayOfTypes($type, array $value, $expected)
     {
         $valueGenerator = new ValueGenerator();
@@ -451,9 +444,7 @@ EOS;
         self::assertSame($expected, $valueGenerator->generate());
     }
 
-    /**
-     * @dataProvider complexArrayWCustomIndent
-     */
+    #[DataProvider('complexArrayWCustomIndent')]
     public function testPropertyDefaultValueCanHandleComplexArrayWCustomIndentOfTypes(
         string $type,
         array $value,
@@ -468,11 +459,11 @@ EOS;
     }
 
     /**
-     * @group 6023
-     * @dataProvider getEscapedParameters
      * @param string $input
      * @param string $expectedEscapedValue
      */
+    #[DataProvider('getEscapedParameters')]
+    #[Group('6023')]
     public function testEscaping($input, $expectedEscapedValue)
     {
         self::assertSame($expectedEscapedValue, ValueGenerator::escape($input, false));
@@ -498,11 +489,8 @@ EOS;
         yield 'resource' => [fopen('php://input', 'r'), 'resource (stream)'];
     }
 
-    /**
-     * @dataProvider invalidValue
-     * @param mixed $value
-     */
-    public function testExceptionInvalidValue($value, string $type): void
+    #[DataProvider('invalidValue')]
+    public function testExceptionInvalidValue(mixed $value, string $type): void
     {
         $valueGenerator = new ValueGenerator($value);
 

--- a/test/Generic/Prototype/PrototypeClassFactoryTest.php
+++ b/test/Generic/Prototype/PrototypeClassFactoryTest.php
@@ -5,25 +5,18 @@ namespace LaminasTest\Code\Generic\Prototype;
 use Laminas\Code\Generic\Prototype\PrototypeClassFactory;
 use LaminasTest\Code\Generator\TestAsset\PrototypeClass;
 use LaminasTest\Code\Generator\TestAsset\PrototypeGenericClass;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group Laminas_Code_Generator
- * @group Laminas_Code_Generator_Php
- */
+#[Group('Laminas_Code_Generator')]
+#[Group('Laminas_Code_Generator_Php')]
 class PrototypeClassFactoryTest extends TestCase
 {
-    /** @var PrototypeClassFactory */
-    protected $prototypeFactory;
+    protected PrototypeClassFactory $prototypeFactory;
 
     protected function setUp(): void
     {
         $this->prototypeFactory = new PrototypeClassFactory();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->prototypeFactory = null;
     }
 
     public function testAddAndGetPrototype()
@@ -45,7 +38,7 @@ class PrototypeClassFactoryTest extends TestCase
     public function testSetNameOnGenericIsCalledOnce()
     {
         $mockProto = $this->getMockBuilder(PrototypeGenericClass::class)
-            ->setMethods(['setName'])
+            ->onlyMethods(['setName'])
             ->getMock();
         $mockProto->expects($this->once())->method('setName')->willReturn('notexist');
         $this->prototypeFactory->setGenericPrototype($mockProto);

--- a/test/Reflection/ClassReflectionTest.php
+++ b/test/Reflection/ClassReflectionTest.php
@@ -6,6 +6,7 @@ use Laminas\Code\Reflection\ClassReflection;
 use Laminas\Code\Reflection\MethodReflection;
 use Laminas\Code\Reflection\PropertyReflection;
 use LaminasTest\Code\Reflection\TestAsset\TestTraitClass3;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_shift;
@@ -13,10 +14,8 @@ use function get_class;
 use function trim;
 use function uniqid;
 
-/**
- * @group Laminas_Reflection
- * @group Laminas_Reflection_Class
- */
+#[Group('Laminas_Reflection')]
+#[Group('Laminas_Reflection_Class')]
 class ClassReflectionTest extends TestCase
 {
     public function testMethodReturns()
@@ -24,7 +23,7 @@ class ClassReflectionTest extends TestCase
         $reflectionClass = new ClassReflection(TestAsset\TestSampleClass2::class);
 
         $methodByName = $reflectionClass->getMethod('getProp1');
-        self::assertEquals(MethodReflection::class, get_class($methodByName));
+        self::assertEquals(MethodReflection::class, $methodByName::class);
 
         $methodsAll = $reflectionClass->getMethods();
         self::assertCount(3, $methodsAll);
@@ -52,7 +51,7 @@ class ClassReflectionTest extends TestCase
         $reflectionClass = new ClassReflection(TestAsset\TestSampleClass::class);
 
         $parent = $reflectionClass->getParentClass();
-        self::assertEquals(ClassReflection::class, get_class($parent));
+        self::assertEquals(ClassReflection::class, $parent::class);
         self::assertEquals('ArrayObject', $parent->getName());
     }
 

--- a/test/Reflection/DocBlock/Tag/AuthorTagTest.php
+++ b/test/Reflection/DocBlock/Tag/AuthorTagTest.php
@@ -3,12 +3,11 @@
 namespace LaminasTest\Code\Reflection\DocBlock\Tag;
 
 use Laminas\Code\Reflection\DocBlock\Tag\AuthorTag;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group      Laminas_Reflection
- * @group      Laminas_Reflection_DocBlock
- */
+#[Group('Laminas_Reflection')]
+#[Group('Laminas_Reflection_DocBlock')]
 class AuthorTagTest extends TestCase
 {
     /** @var AuthorTag */

--- a/test/Reflection/DocBlock/Tag/GenericTagTest.php
+++ b/test/Reflection/DocBlock/Tag/GenericTagTest.php
@@ -3,17 +3,14 @@
 namespace LaminasTest\Code\Reflection\DocBlock\Tag;
 
 use Laminas\Code\Reflection\DocBlock\Tag\GenericTag;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group      Laminas_Reflection
- * @group      Laminas_Reflection_DocBlock
- */
+#[Group('Laminas_Reflection')]
+#[Group('Laminas_Reflection_DocBlock')]
 class GenericTagTest extends TestCase
 {
-    /**
-     * @group Laminas-146
-     */
+    #[Group('Laminas-146')]
     public function testParse()
     {
         $tag = new GenericTag();

--- a/test/Reflection/DocBlock/Tag/LicenseTagTest.php
+++ b/test/Reflection/DocBlock/Tag/LicenseTagTest.php
@@ -3,12 +3,11 @@
 namespace LaminasTest\Code\Reflection\DocBlock\Tag;
 
 use Laminas\Code\Reflection\DocBlock\Tag\LicenseTag;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group      Laminas_Reflection
- * @group      Laminas_Reflection_DocBlock
- */
+#[Group('Laminas_Reflection')]
+#[Group('Laminas_Reflection_DocBlock')]
 class LicenseTagTest extends TestCase
 {
     /** @var LicenseTag */

--- a/test/Reflection/DocBlock/Tag/MethodTagTest.php
+++ b/test/Reflection/DocBlock/Tag/MethodTagTest.php
@@ -3,12 +3,11 @@
 namespace LaminasTest\Code\Reflection\DocBlock\Tag;
 
 use Laminas\Code\Reflection\DocBlock\Tag\MethodTag;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group      Laminas_Reflection
- * @group      Laminas_Reflection_DocBlock
- */
+#[Group('Laminas_Reflection')]
+#[Group('Laminas_Reflection_DocBlock')]
 class MethodTagTest extends TestCase
 {
     public function testParseName()

--- a/test/Reflection/DocBlock/Tag/PropertyTagTest.php
+++ b/test/Reflection/DocBlock/Tag/PropertyTagTest.php
@@ -3,12 +3,11 @@
 namespace LaminasTest\Code\Reflection\DocBlock\Tag;
 
 use Laminas\Code\Reflection\DocBlock\Tag\PropertyTag;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group      Laminas_Reflection
- * @group      Laminas_Reflection_DocBlock
- */
+#[Group('Laminas_Reflection')]
+#[Group('Laminas_Reflection_DocBlock')]
 class PropertyTagTest extends TestCase
 {
     public function testParseName()

--- a/test/Reflection/DocBlock/Tag/ThrowsTagTest.php
+++ b/test/Reflection/DocBlock/Tag/ThrowsTagTest.php
@@ -3,12 +3,11 @@
 namespace LaminasTest\Code\Reflection\DocBlock\Tag;
 
 use Laminas\Code\Reflection\DocBlock\Tag\ThrowsTag;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group      Laminas_Reflection
- * @group      Laminas_Reflection_DocBlock
- */
+#[Group('Laminas_Reflection')]
+#[Group('Laminas_Reflection_DocBlock')]
 class ThrowsTagTest extends TestCase
 {
     public function testAllCharactersFromTypenameAreSupported()

--- a/test/Reflection/DocBlock/Tag/VarTagTest.php
+++ b/test/Reflection/DocBlock/Tag/VarTagTest.php
@@ -3,17 +3,15 @@
 namespace LaminasTest\Code\Reflection\DocBlock\Tag;
 
 use Laminas\Code\Reflection\DocBlock\Tag\VarTag;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group      Laminas_Reflection
- * @group      Laminas_Reflection_DocBlock
- */
+#[Group('Laminas_Reflection')]
+#[Group('Laminas_Reflection_DocBlock')]
 class VarTagTest extends TestCase
 {
-    /**
-     * @dataProvider varTagProvider
-     */
+    #[DataProvider('varTagProvider')]
     public function testParse(
         string $line,
         array $expectedTypes,

--- a/test/Reflection/DocBlockReflectionTest.php
+++ b/test/Reflection/DocBlockReflectionTest.php
@@ -10,12 +10,11 @@ use Laminas\Code\Reflection\DocBlock\Tag\ReturnTag;
 use Laminas\Code\Reflection\DocBlock\Tag\TagInterface;
 use Laminas\Code\Reflection\DocBlock\Tag\ThrowsTag;
 use Laminas\Code\Reflection\DocBlockReflection;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group      Laminas_Reflection
- * @group      Laminas_Reflection_DocBlock
- */
+#[Group('Laminas_Reflection')]
+#[Group('Laminas_Reflection_DocBlock')]
 class DocBlockReflectionTest extends TestCase
 {
     public function testDocBlockShortDescription()

--- a/test/Reflection/FunctionReflectionTest.php
+++ b/test/Reflection/FunctionReflectionTest.php
@@ -6,16 +6,15 @@ use Laminas\Code\Reflection\DocBlockReflection;
 use Laminas\Code\Reflection\Exception\InvalidArgumentException;
 use Laminas\Code\Reflection\FunctionReflection;
 use Laminas\Code\Reflection\ParameterReflection;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_shift;
 use function trim;
 use function uniqid;
 
-/**
- * @group Laminas_Reflection
- * @group Laminas_Reflection_Function
- */
+#[Group('Laminas_Reflection')]
+#[Group('Laminas_Reflection_Function')]
 class FunctionReflectionTest extends TestCase
 {
     public function testParemeterReturn()
@@ -118,6 +117,16 @@ class FunctionReflectionTest extends TestCase
 
     public function testFunctionClosureBodyReturn()
     {
+        $function1  = null;
+        $function2  = null;
+        $function3  = null;
+        $function4  = null;
+        $list1      = [];
+        $list2      = [];
+        $list3      = [];
+        $function8  = null;
+        $function9  = null;
+        $function10 = null;
         require __DIR__ . '/TestAsset/closures.php';
 
         $function = new FunctionReflection($function1);
@@ -222,11 +231,12 @@ class FunctionReflectionTest extends TestCase
         self::assertEquals('function function12() {}', trim($content));
     }
 
-    /**
-     * @group fail
-     */
+    #[Group('fail')]
     public function testFunctionClosureContentsReturnWithoutDocBlock()
     {
+        $function2  = null;
+        $function9  = null;
+        $function10 = null;
         require __DIR__ . '/TestAsset/closures.php';
 
         $function = new FunctionReflection($function2);
@@ -257,6 +267,7 @@ class FunctionReflectionTest extends TestCase
 
     public function testFunctionClosureContentsReturnWithDocBlock()
     {
+        $function9 = null;
         require __DIR__ . '/TestAsset/closures.php';
 
         $function = new FunctionReflection($function9);

--- a/test/Reflection/MethodReflectionTest.php
+++ b/test/Reflection/MethodReflectionTest.php
@@ -5,16 +5,15 @@ namespace LaminasTest\Code\Reflection;
 use Laminas\Code\Reflection\ClassReflection;
 use Laminas\Code\Reflection\MethodReflection;
 use Laminas\Code\Reflection\ParameterReflection;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_shift;
 use function trim;
 use function uniqid;
 
-/**
- * @group      Laminas_Reflection
- * @group      Laminas_Reflection_Method
- */
+#[Group('Laminas_Reflection')]
+#[Group('Laminas_Reflection_Method')]
 class MethodReflectionTest extends TestCase
 {
     public function testDeclaringClassReturn()
@@ -102,9 +101,7 @@ class MethodReflectionTest extends TestCase
         self::assertEquals('', $reflectionMethod->getContents());
     }
 
-    /**
-     * @group 6275
-     */
+    #[Group('6275')]
     public function testMethodContentsReturnWithoutDocBlock()
     {
         $contents         = <<<CONTENTS
@@ -285,7 +282,6 @@ CONTENTS;
         );
     }
 
-    /** @requires PHP >= 8.0 */
     public function testGetPrototypeMethodForPromotedParameter(): void
     {
         $reflectionMethod = new MethodReflection(
@@ -316,9 +312,7 @@ CONTENTS;
         );
     }
 
-    /**
-     * @group 5062
-     */
+    #[Group('5062')]
     public function testGetContentsWithCoreClass()
     {
         $reflectionMethod = new MethodReflection('DateTime', 'format');
@@ -343,9 +337,7 @@ CONTENTS;
         self::assertSame('', $reflectionMethod->getContents());
     }
 
-    /**
-     * @group 6275
-     */
+    #[Group('6275')]
     public function testCodeGetContentsDoesNotThrowExceptionOnDocBlock()
     {
         $contents = <<<'CONTENTS'
@@ -374,9 +366,7 @@ CONTENTS;
         self::assertEquals($contents, $reflectionMethod->getContents(false));
     }
 
-    /**
-     * @group 6275
-     */
+    #[Group('6275')]
     public function testCodeGetBodyReturnsEmptyWithCommentedFunction()
     {
         $this->expectException('ReflectionException');
@@ -384,9 +374,7 @@ CONTENTS;
         $reflectionMethod->getBody();
     }
 
-    /**
-     * @group 6620
-     */
+    #[Group('6620')]
     public function testCanParseClassBodyWhenUsingTrait()
     {
         require_once __DIR__ . '/TestAsset/TestTraitClass1.php';

--- a/test/Reflection/ParameterReflectionTest.php
+++ b/test/Reflection/ParameterReflectionTest.php
@@ -9,13 +9,13 @@ use LaminasTest\Code\Reflection\TestAsset\ClassWithPromotedParameter;
 use LaminasTest\Code\TestAsset\ClassTypeHintedClass;
 use LaminasTest\Code\TestAsset\DocBlockOnlyHintsClass;
 use LaminasTest\Code\TestAsset\InternalHintsClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use ReflectionType;
 
-/**
- * @group Laminas_Reflection
- * @group Laminas_Reflection_Parameter
- */
+#[Group('Laminas_Reflection')]
+#[Group('Laminas_Reflection_Parameter')]
 class ParameterReflectionTest extends TestCase
 {
     public function testDeclaringClassReturn()
@@ -45,12 +45,8 @@ class ParameterReflectionTest extends TestCase
         self::assertInstanceOf(ClassReflection::class, $parameter->getClass());
     }
 
-    /**
-     * @dataProvider paramType
-     * @param string $param
-     * @param string $type
-     */
-    public function testTypeReturn($param, $type)
+    #[DataProvider('paramType')]
+    public function testTypeReturn(string $param, string $type): void
     {
         $parameter = new Reflection\ParameterReflection(
             [TestAsset\TestSampleClass5::class, 'doSomething'],
@@ -61,9 +57,8 @@ class ParameterReflectionTest extends TestCase
 
     /**
      * This test covers type detection when not all params declared in phpDoc block
-     *
-     * @dataProvider paramTypeWithNotAllParamsDeclared
      */
+    #[DataProvider('paramTypeWithNotAllParamsDeclared')]
     public function testTypeReturnWithNotAllParamsDeclared(string $param, string $type): void
     {
         $parameter = new Reflection\ParameterReflection(
@@ -112,16 +107,14 @@ class ParameterReflectionTest extends TestCase
         ];
     }
 
-    /**
-     * @group zendframework/zend-code#29
-     * @dataProvider reflectionHints
-     * @param string $className
-     * @param string $methodName
-     * @param string $parameterName
-     * @param string $expectedType
-     */
-    public function testGetType($className, $methodName, $parameterName, $expectedType)
-    {
+    #[Group('zendframework/zend-code#29')]
+    #[DataProvider('reflectionHints')]
+    public function testGetType(
+        string $className,
+        string $methodName,
+        string $parameterName,
+        string $expectedType
+    ): void {
         $reflection = new Reflection\ParameterReflection(
             [$className, $methodName],
             $parameterName
@@ -133,16 +126,14 @@ class ParameterReflectionTest extends TestCase
         self::assertSame($expectedType, $type->getName());
     }
 
-    /**
-     * @group zendframework/zend-code#29
-     * @dataProvider reflectionHints
-     * @param string $className
-     * @param string $methodName
-     * @param string $parameterName
-     * @param string $expectedType
-     */
-    public function testDetectType($className, $methodName, $parameterName, $expectedType)
-    {
+    #[Group('zendframework/zend-code#29')]
+    #[DataProvider('reflectionHints')]
+    public function testDetectType(
+        string $className,
+        string $methodName,
+        string $parameterName,
+        string $expectedType
+    ): void {
         $reflection = new Reflection\ParameterReflection(
             [$className, $methodName],
             $parameterName
@@ -176,14 +167,9 @@ class ParameterReflectionTest extends TestCase
         ];
     }
 
-    /**
-     * @group zendframework/zend-code#29
-     * @dataProvider docBlockHints
-     * @param string $className
-     * @param string $methodName
-     * @param string $parameterName
-     */
-    public function testGetTypeWithDocBlockOnlyTypes($className, $methodName, $parameterName)
+    #[Group('zendframework/zend-code#29')]
+    #[DataProvider('docBlockHints')]
+    public function testGetTypeWithDocBlockOnlyTypes(string $className, string $methodName, string $parameterName): void
     {
         $reflection = new Reflection\ParameterReflection(
             [$className, $methodName],
@@ -193,16 +179,14 @@ class ParameterReflectionTest extends TestCase
         self::assertNull($reflection->getType());
     }
 
-    /**
-     * @group zendframework/zend-code#29
-     * @dataProvider docBlockHints
-     * @param string $className
-     * @param string $methodName
-     * @param string $parameterName
-     * @param string $expectedType
-     */
-    public function testDetectTypeWithDocBlockOnlyTypes($className, $methodName, $parameterName, $expectedType)
-    {
+    #[Group('zendframework/zend-code#29')]
+    #[DataProvider('docBlockHints')]
+    public function testDetectTypeWithDocBlockOnlyTypes(
+        string $className,
+        string $methodName,
+        string $parameterName,
+        string $expectedType
+    ): void {
         $reflection = new Reflection\ParameterReflection(
             [$className, $methodName],
             $parameterName
@@ -229,7 +213,6 @@ class ParameterReflectionTest extends TestCase
         ];
     }
 
-    /** @requires PHP >= 8.0 */
     public function testPromotedParameter(): void
     {
         $reflection = new Reflection\ParameterReflection(

--- a/test/Reflection/PropertyReflectionTest.php
+++ b/test/Reflection/PropertyReflectionTest.php
@@ -4,12 +4,11 @@ namespace LaminasTest\Code\Reflection;
 
 use Laminas\Code\Reflection\ClassReflection;
 use Laminas\Code\Reflection\PropertyReflection;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group      Laminas_Reflection
- * @group      Laminas_Reflection_Property
- */
+#[Group('Laminas_Reflection')]
+#[Group('Laminas_Reflection_Property')]
 class PropertyReflectionTest extends TestCase
 {
     public function testDeclaringClassReturn()

--- a/test/Reflection/ReflectionDocBlockTagTest.php
+++ b/test/Reflection/ReflectionDocBlockTagTest.php
@@ -4,13 +4,13 @@ namespace LaminasTest\Code\Reflection;
 
 use Laminas\Code\Generator\DocBlock\Tag\VarTag;
 use Laminas\Code\Reflection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group      Laminas_Reflection
- * @group      Laminas_Reflection_DocBlock
- * @group      Laminas_Reflection_DocBlock_Tag
- */
+#[Group('Laminas_Reflection')]
+#[Group('Laminas_Reflection_DocBlock')]
+#[Group('Laminas_Reflection_DocBlock_Tag')]
 class ReflectionDocBlockTagTest extends TestCase
 {
     public function testTagDescriptionIsReturned()
@@ -90,9 +90,7 @@ class ReflectionDocBlockTagTest extends TestCase
         );
     }
 
-    /**
-     * @group Laminas-8307
-     */
+    #[Group('Laminas-8307')]
     public function testNamespaceInParam()
     {
         $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass7::class);
@@ -125,9 +123,7 @@ class ReflectionDocBlockTagTest extends TestCase
         );
     }
 
-    /**
-     * @group Laminas-8307
-     */
+    #[Group('Laminas-8307')]
     public function testReturnClassWithNamespace()
     {
         $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass7::class);
@@ -137,9 +133,7 @@ class ReflectionDocBlockTagTest extends TestCase
         self::assertEquals('Laminas\Code\Reflection\DocBlock', $paramTag->getType());
     }
 
-    /**
-     * @dataProvider propertyVarDocProvider
-     */
+    #[DataProvider('propertyVarDocProvider')]
     public function testPropertyVarDoc(
         string $property,
         array $expectedTypes,

--- a/test/Scanner/DocBlockScannerTest.php
+++ b/test/Scanner/DocBlockScannerTest.php
@@ -3,18 +3,15 @@
 namespace LaminasTest\Code\Scanner;
 
 use Laminas\Code\Scanner\DocBlockScanner;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function str_replace;
 
-/**
- * @group      Laminas_Code_Scanner
- */
+#[Group('Laminas_Code_Scanner')]
 class DocBlockScannerTest extends TestCase
 {
-    /**
-     * @group Laminas-110
-     */
+    #[Group('Laminas-110')]
     public function testDocBlockScannerParsesTagsWithNoValuesProperly()
     {
         $docComment   = <<<EOB


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Upgrading to PHPUnit 10 and Psalm 5.7 (required for `sebastian/diff` v5), converting all `@requires` `@covers` and `@dataProvider` annotations to PHP 8 attributes. Obsolete annotations like `@requires PHP >= 8.0` were removed as we already require PHP 8.1 in `composer.json`

I'm not sure how to proceed with Psalm errors here - I am unable to run it locally to re-generate the baseline file. @Ocramius let me know what you think.

Replaces #170 