### PR TITLE
Non-variadic parameter should not throw exception when calling `ParameterGenerator#setVariadic(false)` with an existing default value

### DIFF
--- a/src/Generator/ParameterGenerator.php
+++ b/src/Generator/ParameterGenerator.php
@@ -257,11 +257,11 @@ class ParameterGenerator extends AbstractGenerator
     public function setVariadic($variadic)
     {
         $this->variadic = (bool) $variadic;
-        
+
         if (true === $this->variadic && isset($this->defaultValue)) {
             throw new Exception\InvalidArgumentException('Variadic parameter cannot have a default value');
         }
-        
+
         return $this;
     }
 

--- a/src/Generator/ParameterGenerator.php
+++ b/src/Generator/ParameterGenerator.php
@@ -256,12 +256,12 @@ class ParameterGenerator extends AbstractGenerator
      */
     public function setVariadic($variadic)
     {
-        if (isset($this->defaultValue)) {
+        $this->variadic = (bool) $variadic;
+        
+        if (true === $this->variadic && isset($this->defaultValue)) {
             throw new Exception\InvalidArgumentException('Variadic parameter cannot have a default value');
         }
-
-        $this->variadic = (bool) $variadic;
-
+        
         return $this;
     }
 

--- a/test/Generator/ParameterGeneratorTest.php
+++ b/test/Generator/ParameterGeneratorTest.php
@@ -558,8 +558,9 @@ class ParameterGeneratorTest extends TestCase
         $parameter->setType('int');
         $parameter->setPosition(1);
         $parameter->setVariadic(false);
-        $this->expectNotToPerformAssertions();
-        $parameter->setDefaultValue([]);
+        self::assertSame('int $parameter', $parameter->generate());
+        $parameter->setDefaultValue(7);
+        self::assertSame('int $parameter = 7', $parameter->generate());
     }
 
     public function testMakingParameterVariadicWithExistingDefaultValueThrowsInvalidArgumentException(): void
@@ -585,9 +586,10 @@ class ParameterGeneratorTest extends TestCase
         $parameter->setName('parameter');
         $parameter->setType('int');
         $parameter->setPosition(1);
-        $parameter->setDefaultValue([]);
-        $this->expectNotToPerformAssertions();
+        $parameter->setDefaultValue(7);
+        self::assertSame('int $parameter = 7', $parameter->generate());
         $parameter->setVariadic(false);
+        self::assertSame('int $parameter = 7', $parameter->generate());
     }
 
     #[Group('zendframework/zend-code#29')]

--- a/test/Generator/ParameterGeneratorTest.php
+++ b/test/Generator/ParameterGeneratorTest.php
@@ -561,7 +561,7 @@ class ParameterGeneratorTest extends TestCase
         $this->expectNotToPerformAssertions();
         $parameter->setDefaultValue([]);
     }
-    
+
     public function testMakingParameterVariadicWithExistingDefaultValueThrowsInvalidArgumentException(): void
     {
         $parameter = new ParameterGenerator();
@@ -577,7 +577,7 @@ class ParameterGeneratorTest extends TestCase
 
         $parameter->setVariadic(true);
     }
-    
+
     public function testMakingParameterNonVariadicWithExistingDefaultValue(): void
     {
         $parameter = new ParameterGenerator();

--- a/test/Generator/ParameterGeneratorTest.php
+++ b/test/Generator/ParameterGeneratorTest.php
@@ -550,6 +550,18 @@ class ParameterGeneratorTest extends TestCase
         $parameter->setDefaultValue([]);
     }
 
+    public function testAssigningDefaultValueToNonVariadicParameter(): void
+    {
+        $parameter = new ParameterGenerator();
+
+        $parameter->setName('parameter');
+        $parameter->setType('int');
+        $parameter->setPosition(1);
+        $parameter->setVariadic(false);
+        $this->expectNotToPerformAssertions();
+        $parameter->setDefaultValue([]);
+    }
+    
     public function testMakingParameterVariadicWithExistingDefaultValueThrowsInvalidArgumentException(): void
     {
         $parameter = new ParameterGenerator();
@@ -564,6 +576,18 @@ class ParameterGeneratorTest extends TestCase
         $this->expectExceptionMessage('Variadic parameter cannot have a default value');
 
         $parameter->setVariadic(true);
+    }
+    
+    public function testMakingParameterNonVariadicWithExistingDefaultValue(): void
+    {
+        $parameter = new ParameterGenerator();
+
+        $parameter->setName('parameter');
+        $parameter->setType('int');
+        $parameter->setPosition(1);
+        $parameter->setDefaultValue([]);
+        $this->expectNotToPerformAssertions();
+        $parameter->setVariadic(false);
     }
 
     #[Group('zendframework/zend-code#29')]


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Fix the changes introduce in PR https://github.com/laminas/laminas-code/pull/72 by ensuring call to `setVariadic` should not throw exception when parameter is non variadic.