### PR TITLE
Use output mode configured in `ValueGenerator` instance

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1874,6 +1874,7 @@
       <code>simpleArray</code>
       <code>unsortedKeysArray</code>
       <code>validConstantTypes</code>
+      <code>multipleOutputArray</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/Generic/Prototype/PrototypeClassFactoryTest.php">

--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -371,7 +371,7 @@ class ValueGenerator extends AbstractGenerator
                     $newType = self::TYPE_AUTO;
                 }
 
-                $curValue = new self($curValue, $newType, self::OUTPUT_MULTIPLE_LINE, $this->getConstants());
+                $curValue = new self($curValue, $newType, $this->outputMode, $this->getConstants());
                 $curValue->setIndentation($this->indentation);
             }
         }

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -19,7 +19,6 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function fopen;
-use function sprintf;
 use function str_replace;
 
 #[CoversClass(ValueGenerator::class)]
@@ -497,5 +496,56 @@ EOS;
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Type "' . $type . '" is unknown or cannot be used');
         $valueGenerator->generate();
+    }
+
+    /**
+     * @param ValueGenerator::OUTPUT_* $outputMode
+     */
+    #[DataProvider('multipleOutputArray')]
+    public function testArrayWithOutputMode(
+        array $array,
+        string $type,
+        string $outputMode,
+        string $output
+    ): void {
+        $valueGenerator = new ValueGenerator($array, $type, $outputMode);
+
+        self::assertSame($valueGenerator->generate(), $output);
+    }
+
+    /**
+     * Data provider for testArrayWithOutputMode test
+     */
+    public static function multipleOutputArray(): array
+    {
+        $array = [
+            'foo' => [
+                'bar',
+            ],
+        ];
+
+        $singleLine   = '[\'foo\' => [\'bar\']]';
+        $multipleLine = <<<EOS
+[
+    'foo' => [
+        'bar',
+    ],
+]
+EOS;
+
+        return [
+            'singleLine'   => [
+                $array,
+                ValueGenerator::TYPE_ARRAY_SHORT,
+                ValueGenerator::OUTPUT_SINGLE_LINE,
+                $singleLine,
+            ],
+            'multipleLine' => [
+                $array,
+                ValueGenerator::TYPE_ARRAY_SHORT,
+                ValueGenerator::OUTPUT_MULTIPLE_LINE,
+                $multipleLine,
+            ],
+        ];
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

When I want to generate code for an array with the "single line" output, I expect the result to be on a single line. However in the case the array have deeper depth than 1, the result is on multi lines, because the original output mode is not given when generating the child nodes.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
