### PR TITLE
Fix generating null return type from reflection in TypeGenerator

### DIFF
--- a/src/Generator/TypeGenerator.php
+++ b/src/Generator/TypeGenerator.php
@@ -69,7 +69,7 @@ final class TypeGenerator implements GeneratorInterface
 
         return new self(
             $atomicType,
-            $atomicType->type !== 'mixed' && $atomicType !== 'null' && $type->allowsNull()
+            $atomicType->type !== 'mixed' && $atomicType->type !== 'null' && $type->allowsNull()
         );
     }
 


### PR DESCRIPTION
The TypeGenerator failed with "type 'null' cannot be nullable" when `fromReflectionType()` was called for a method with a return type "null" due to a incorrect comparison with the string "null". This change corrects the comparison so that such methods are reflected without errors.

Obvious fix.

Resolves: #185 