### PR TITLE
Use expected DEPLOY_TOKEN env for docs build workflow

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -12,5 +12,5 @@ jobs:
       - name: Build Docs
         uses: laminas/documentation-theme/github-actions/docs@master
         env:
-          DOCS_TOKEN: ${{ secrets.ORGANIZATION_ADMIN_KEY }}
+          DEPLOY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As noted in #153 docs are currently not deployed due to incorrect, old?, setup used in docs workflow.