### PR TITLE
Allow enum value to be backed by an empty string

### DIFF
--- a/src/Generator/EnumGenerator/Cases/CaseFactory.php
+++ b/src/Generator/EnumGenerator/Cases/CaseFactory.php
@@ -26,7 +26,7 @@ final class CaseFactory
      *          cases: array<non-empty-string, int>,
      *      }|array{
      *          type: 'string',
-     *          cases: array<non-empty-string, non-empty-string>,
+     *          cases: array<non-empty-string, string>,
      *      },
      * } $options
      * @return BackedCases|PureCases

--- a/src/Generator/EnumGenerator/EnumGenerator.php
+++ b/src/Generator/EnumGenerator/EnumGenerator.php
@@ -80,7 +80,7 @@ final class EnumGenerator
      *      name: non-empty-string,
      *      backedCases: array{
      *          type: 'int'|'string',
-     *          cases: array<non-empty-string, int|non-empty-string>,
+     *          cases: array<non-empty-string, int|string>,
      *      },
      * } $options
      */


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Currently, the `EnumGenerator` class enforces (in its Psalm typings) that a case of a backed enumeration is backed by `int|non-empty-string`. However, the `non-empty-string` constraint is unnecessarily strict, since (AFAIK) 
an empty string is an entirely valid value (not name!) for a backed enum case.

This change relaxes the Psalm type hints a bit in order to allow this:

```php
$enum = EnumGenerator::withConfig([
  "name"        => "Foo",
  "backedCases" => [
    "type"  => "string",
    "cases" => [
      "empty" => "",
      "foo"   => "foo",
      "bar"   => "bar",
    ],
  ]
]);
```

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
