### PR TITLE
Add PHP 8.3 to supported PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "homepage": "https://laminas.dev",
     "license": "BSD-3-Clause",
     "require": {
-        "php": "~8.1.0 || ~8.2.0"
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
     },
     "require-dev": {
         "ext-phar": "*",


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation |no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Requires:

 - [ ] PHP 8.3 Support laminas-stdlib: https://github.com/laminas/laminas-stdlib/commit/8ec8790aed1d0aead6d0155ff8ba15a6d06810c4 (merged not yet released)

### Description

This will just make sure if the current supported generators still work as expected in PHP 8.3. The features provided by PHP 8.3 can be build then ontop of this. A list of features which could be tackled by somebody can be found in the following issue: https://github.com/laminas/laminas-code/issues/190

