### PR TITLE
Return static instance on abstract class setters

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -37,10 +37,10 @@
   </file>
   <file src="src/Generator/AbstractMemberGenerator.php">
     <PossiblyUnusedReturnValue>
-      <code>AbstractMemberGenerator</code>
-      <code>AbstractMemberGenerator</code>
-      <code>AbstractMemberGenerator</code>
-      <code>AbstractMemberGenerator</code>
+      <code>static</code>
+      <code>static</code>
+      <code>static</code>
+      <code>static</code>
     </PossiblyUnusedReturnValue>
     <RedundantCastGivenDocblockType>
       <code>(string) $name</code>

--- a/src/Generator/AbstractGenerator.php
+++ b/src/Generator/AbstractGenerator.php
@@ -38,7 +38,7 @@ abstract class AbstractGenerator implements GeneratorInterface
 
     /**
      * @param  bool $isSourceDirty
-     * @return AbstractGenerator
+     * @return static
      */
     public function setSourceDirty($isSourceDirty = true)
     {
@@ -56,7 +56,7 @@ abstract class AbstractGenerator implements GeneratorInterface
 
     /**
      * @param  string $indentation
-     * @return AbstractGenerator
+     * @return static
      */
     public function setIndentation($indentation)
     {
@@ -74,7 +74,7 @@ abstract class AbstractGenerator implements GeneratorInterface
 
     /**
      * @param  ?string $sourceContent
-     * @return AbstractGenerator
+     * @return static
      */
     public function setSourceContent($sourceContent)
     {
@@ -93,7 +93,7 @@ abstract class AbstractGenerator implements GeneratorInterface
     /**
      * @param  array|Traversable $options
      * @throws Exception\InvalidArgumentException
-     * @return AbstractGenerator
+     * @return static
      */
     public function setOptions($options)
     {

--- a/src/Generator/AbstractMemberGenerator.php
+++ b/src/Generator/AbstractMemberGenerator.php
@@ -27,7 +27,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
 
     /**
      * @param  int|int[] $flags
-     * @return AbstractMemberGenerator
+     * @return static
      */
     public function setFlags($flags)
     {
@@ -46,7 +46,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
 
     /**
      * @param  int $flag
-     * @return AbstractMemberGenerator
+     * @return static
      */
     public function addFlag($flag)
     {
@@ -56,7 +56,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
 
     /**
      * @param  int $flag
-     * @return AbstractMemberGenerator
+     * @return static
      */
     public function removeFlag($flag)
     {
@@ -66,7 +66,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
 
     /**
      * @param  bool $isAbstract
-     * @return AbstractMemberGenerator
+     * @return static
      */
     public function setAbstract($isAbstract)
     {
@@ -83,7 +83,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
 
     /**
      * @param  bool $isInterface
-     * @return AbstractMemberGenerator
+     * @return static
      */
     public function setInterface($isInterface)
     {
@@ -100,7 +100,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
 
     /**
      * @param  bool $isFinal
-     * @return AbstractMemberGenerator
+     * @return static
      */
     public function setFinal($isFinal)
     {
@@ -117,7 +117,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
 
     /**
      * @param  bool $isStatic
-     * @return AbstractMemberGenerator
+     * @return static
      */
     public function setStatic($isStatic)
     {
@@ -134,7 +134,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
 
     /**
      * @param  string $visibility
-     * @return AbstractMemberGenerator
+     * @return static
      */
     public function setVisibility($visibility)
     {
@@ -173,7 +173,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
 
     /**
      * @param  string $name
-     * @return AbstractMemberGenerator
+     * @return static
      */
     public function setName($name)
     {
@@ -192,7 +192,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
     /**
      * @param  DocBlockGenerator|string $docBlock
      * @throws Exception\InvalidArgumentException
-     * @return AbstractMemberGenerator
+     * @return static
      */
     public function setDocBlock($docBlock)
     {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no/yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR improves static analysis when using the setters that are located in the abstract generators:
Instead of returning with type `Abstract*` on setters, the `static` instance will be returned.
This makes static analyzers understand a fluent approach better.

For example:


```php
(new MethodGenerator('getX'))
    ->setStatic(true)
    // > This would previously result in the static analyzer to believe the type is `AbstractMemberGenerator`
    ->setBody('return '.$code)
    ->setReturnType(ClassMapCollection::class)
```

Resulting in issues like:

```
>   54     Parameter #1 $method of method
         Laminas\Code\Generator\ClassGenerator::addMethodFromGenerator()
         expects Laminas\Code\Generator\MethodGenerator,
         Laminas\Code\Generator\AbstractMemberGenerator given.
```

