### PR TITLE
Fix PropertyTag::setPropertyName() deprecation warning

### DIFF
--- a/src/Generator/DocBlock/Tag/PropertyTag.php
+++ b/src/Generator/DocBlock/Tag/PropertyTag.php
@@ -37,7 +37,7 @@ class PropertyTag extends AbstractTypeableTag implements TagInterface
      */
     public function setPropertyName($propertyName)
     {
-        $this->propertyName = ltrim((string) $propertyName, '$');
+        $this->propertyName = ! empty($propertyName) ? ltrim($propertyName, '$') : '';
         return $this;
     }
 

--- a/src/Generator/DocBlock/Tag/PropertyTag.php
+++ b/src/Generator/DocBlock/Tag/PropertyTag.php
@@ -37,7 +37,7 @@ class PropertyTag extends AbstractTypeableTag implements TagInterface
      */
     public function setPropertyName($propertyName)
     {
-        $this->propertyName = $propertyName ? ltrim($propertyName, '$') : null;
+        $this->propertyName = ltrim((string) $propertyName, '$');
         return $this;
     }
 

--- a/src/Generator/DocBlock/Tag/PropertyTag.php
+++ b/src/Generator/DocBlock/Tag/PropertyTag.php
@@ -37,7 +37,7 @@ class PropertyTag extends AbstractTypeableTag implements TagInterface
      */
     public function setPropertyName($propertyName)
     {
-        $this->propertyName = ltrim($propertyName, '$');
+        $this->propertyName = $propertyName ? ltrim($propertyName, '$') : null;
         return $this;
     }
 


### PR DESCRIPTION
```
ErrorException: Deprecated: ltrim(): Passing null to parameter #1 ($string) of type string is deprecated
#18 /vendor/laminas/laminas-code/src/Generator/DocBlock/Tag/ParamTag.php(55): Laminas\Code\Generator\DocBlock\Tag\ParamTag::setVariableName
#17 /vendor/laminas/laminas-code/src/Generator/DocBlock/TagManager.php(59): Laminas\Code\Generator\DocBlock\TagManager::createTagFromReflection
#16 /vendor/laminas/laminas-code/src/Generator/DocBlockGenerator.php(48): Laminas\Code\Generator\DocBlockGenerator::fromReflection
#15 /vendor/laminas/laminas-code/src/Generator/MethodGenerator.php(47): Laminas\Code\Generator\MethodGenerator::fromReflection
```

