### PR TITLE
Remove extra space before return‑type colon in `MethodGenerator`

### DIFF
--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -376,7 +376,7 @@ class MethodGenerator extends AbstractMemberGenerator implements Stringable
         $output .= ')';
 
         if ($this->returnType) {
-            $output .= ' : ' . $this->returnType->generate();
+            $output .= ': ' . $this->returnType->generate();
         }
 
         if ($this->isAbstract()) {

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -805,7 +805,7 @@ class TestSampleSingleClass
      *
      * @return bool
      */
-    protected function withParamsAndReturnType($mixed, array $array, ?callable $callable = null, ?int $int = 0) : bool
+    protected function withParamsAndReturnType($mixed, array $array, ?callable $callable = null, ?int $int = 0): bool
     {
         /* test test */
         return true;

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -127,7 +127,7 @@ class MethodGeneratorTest extends TestCase
 
         $methodGenerator = MethodGenerator::copyMethodSignature($ref);
         $target          = <<<'EOS'
-    protected function withParamsAndReturnType($mixed, array $array, ?callable $callable = null, ?int $int = 0) : bool
+    protected function withParamsAndReturnType($mixed, array $array, ?callable $callable = null, ?int $int = 0): bool
     {
     }
 
@@ -373,7 +373,7 @@ CODE;
         $methodGenerator->setReturnType('bar');
 
         $expected = <<<'PHP'
-    public function foo() : \bar
+    public function foo(): \bar
     {
     }
 
@@ -409,7 +409,7 @@ PHP;
     {
         $methodGenerator = MethodGenerator::fromReflection(new MethodReflection($className, $methodName));
 
-        self::assertStringMatchesFormat('%A) : ' . $expectedReturnSignature . '%w{%A', $methodGenerator->generate());
+        self::assertStringMatchesFormat('%A): ' . $expectedReturnSignature . '%w{%A', $methodGenerator->generate());
     }
 
     /**


### PR DESCRIPTION
PSR‑12 and Laminas CS v2/v3 specify **no space** before the `:` in return‑type declarations (`function foo(): bool`).
But `MethodGenerator::generate()` still outputs `) : bool`, a legacy Zend CS formatting.  
This patch drops the extra space, bringing generated code in line with current standards.
Behaviour is unchanged; all affected tests are updated and passing.

|    Q          |   A
|-------------- | ------
| QA            | yes


* **What changed?**  
  Replaced `' : '` with `': '` in `MethodGenerator::generate()`.

* **Why?**  
  To comply with PSR‑12 / Laminas CS v2 return‑type spacing.

* **Impact**  
  Cosmetic only; no functional changes. Test suite green.
