### PR TITLE
Remove defunct `ReflectionProperty::setAccessible()` calls

### DIFF
--- a/test/Generator/ParameterGeneratorTest.php
+++ b/test/Generator/ParameterGeneratorTest.php
@@ -220,8 +220,6 @@ class ParameterGeneratorTest extends TestCase
 
         $reflectionOmitDefaultValue = new ReflectionProperty($parameterGenerator, 'omitDefaultValue');
 
-        $reflectionOmitDefaultValue->setAccessible(true);
-
         self::assertTrue($reflectionOmitDefaultValue->getValue($parameterGenerator));
     }
 

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -296,8 +296,6 @@ EOS;
         self::assertInstanceOf(TypeGenerator::class, $propertyGenerator->getType());
         $reflectionOmitDefaultValue = new ReflectionProperty($propertyGenerator, 'omitDefaultValue');
 
-        $reflectionOmitDefaultValue->setAccessible(true);
-
         self::assertTrue($reflectionOmitDefaultValue->getValue($propertyGenerator));
     }
 

--- a/test/Generator/TraitGeneratorTest.php
+++ b/test/Generator/TraitGeneratorTest.php
@@ -534,7 +534,6 @@ CODE;
         $reflectedClass = new ReflectionClass($classGenerator);
 
         $reflection = $reflectedClass->getProperty('flags');
-        $reflection->setAccessible(true);
 
         return $reflection->getValue($classGenerator);
     }

--- a/test/Reflection/ParameterReflectionTest.php
+++ b/test/Reflection/ParameterReflectionTest.php
@@ -122,7 +122,12 @@ class ParameterReflectionTest extends TestCase
 
         $type = $reflection->getType();
 
+        if(PHP_VERSION_ID >= 80500 && $expectedType == 'self' ){
+            $expectedType = $className;
+        }
+
         self::assertInstanceOf(ReflectionType::class, $type);
+        
         self::assertSame($expectedType, $type->getName());
     }
 

--- a/test/Reflection/ParameterReflectionTest.php
+++ b/test/Reflection/ParameterReflectionTest.php
@@ -14,6 +14,8 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use ReflectionType;
 
+use const PHP_VERSION_ID;
+
 #[Group('Laminas_Reflection')]
 #[Group('Laminas_Reflection_Parameter')]
 class ParameterReflectionTest extends TestCase
@@ -122,12 +124,12 @@ class ParameterReflectionTest extends TestCase
 
         $type = $reflection->getType();
 
-        if(PHP_VERSION_ID >= 80500 && $expectedType == 'self' ){
+        if (PHP_VERSION_ID >= 80500 && $expectedType == 'self') {
             $expectedType = $className;
         }
 
         self::assertInstanceOf(ReflectionType::class, $type);
-        
+
         self::assertSame($expectedType, $type->getName());
     }
 


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yesn

### Description

ReflectionProperty::setAccessible() is deprecated as of PHP 8.5.  
Updated code to remove reliance on it to ensure forward compatibility.