### PR TITLE
Add AttributeGenerator and class-level attribute support

### DIFF
--- a/docs/book/generator/examples.md
+++ b/docs/book/generator/examples.md
@@ -95,6 +95,68 @@ class Foo
 }
 ```
 
+### Generating PHP classes with attributes
+
+`Laminas\Code\Generator\AttributeGenerator` generates a single PHP attribute declaration, which can
+then be attached to a `Laminas\Code\Generator\ClassGenerator` instance.
+
+Attribute names are always rendered as fully qualified names, so that the generated code is valid
+regardless of the `use` statements surrounding it.
+
+```php
+use Laminas\Code\Generator\AttributeGenerator;
+use Laminas\Code\Generator\ClassGenerator;
+
+$class = new ClassGenerator();
+$class
+    ->setName('MyEntity')
+    ->setAttributes([
+        AttributeGenerator::fromName(\Doctrine\ORM\Mapping\Entity::class),
+        AttributeGenerator::fromName(
+            \Doctrine\ORM\Mapping\Table::class,
+            ['name' => 'my_entity']
+        ),
+    ])
+    ->addAttribute(AttributeGenerator::fromName('My\Attributes\Deprecated', ['since 1.2.0']));
+
+echo $class->generate();
+```
+
+The above results in the following:
+
+```php
+#[\Doctrine\ORM\Mapping\Entity]
+#[\Doctrine\ORM\Mapping\Table(name: 'my_entity')]
+#[\My\Attributes\Deprecated('since 1.2.0')]
+class MyEntity
+{
+}
+```
+
+Arguments with `string` keys are rendered as named arguments, while arguments with `int` keys are
+rendered as positional ones. As in hand-written PHP, positional arguments cannot follow named ones.
+
+Only values that are valid constant expressions may be used as arguments: `null`, `bool`, `int`,
+`float`, `string`, `array` and enum cases. Anything else results in an
+`Laminas\Code\Generator\Exception\InvalidArgumentException`.
+
+Attributes declared on existing symbols can be read back through reflection:
+
+```php
+use Laminas\Code\Generator\AttributeGenerator;
+
+// list<AttributeGenerator>
+$attributes = AttributeGenerator::fromReflector(new ReflectionClass(MyEntity::class));
+
+// a single ReflectionAttribute can be converted too
+$attribute = AttributeGenerator::fromReflectionAttribute(
+    (new ReflectionClass(MyEntity::class))->getAttributes()[0]
+);
+```
+
+`AttributeGenerator::fromReflector()` accepts any reflector that can carry attributes: classes,
+class constants, functions, methods, parameters and properties.
+
 ### Generating PHP classes with class methods
 
 `Laminas\Code\Generator\ClassGenerator` allows you to attach methods with optional content to your

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1091,6 +1091,11 @@
       <code>testSetFlagsWithArray</code>
     </MissingReturnType>
   </file>
+  <file src="test/Generator/AttributeGeneratorTest.php">
+    <PossiblyUnusedMethod>
+      <code>validAttributes</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/Generator/Cases/BackedCasesTest.php">
     <InvalidArgument>
       <code><![CDATA['bool']]></code>

--- a/src/Generator/AttributeGenerator.php
+++ b/src/Generator/AttributeGenerator.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Laminas\Code\Generator;
+
+use Laminas\Code\Generator\Exception\InvalidArgumentException;
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionClassConstant;
+use ReflectionFunction;
+use ReflectionMethod;
+use ReflectionParameter;
+use ReflectionProperty;
+use UnitEnum;
+
+use function addcslashes;
+use function array_is_list;
+use function array_keys;
+use function array_map;
+use function assert;
+use function get_debug_type;
+use function implode;
+use function is_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_string;
+use function ltrim;
+use function preg_match;
+use function sprintf;
+use function var_export;
+
+/**
+ * Generates a single PHP attribute declaration, such as `#[\Foo\Bar(1, baz: 'taz')]`.
+ *
+ * Attribute names are always generated as fully qualified names, so that the generated
+ * code is valid regardless of the `use` statements (or lack thereof) surrounding it.
+ *
+ * @psalm-immutable
+ */
+final class AttributeGenerator implements GeneratorInterface
+{
+    private const LABEL_PATTERN         = '[a-zA-Z_\\x80-\\xff][a-zA-Z0-9_\\x80-\\xff]*';
+    private const NAME_PATTERN          = '/^' . self::LABEL_PATTERN . '(\\\\' . self::LABEL_PATTERN . ')*$/';
+    private const ARGUMENT_NAME_PATTERN = '/^' . self::LABEL_PATTERN . '$/';
+
+    /**
+     * @param non-empty-string $name      fully qualified attribute name, without leading `\`
+     * @param array<array-key, mixed> $arguments positional (`int` keys) and named (`string` keys) arguments
+     */
+    private function __construct(
+        private readonly string $name,
+        private readonly array $arguments,
+    ) {
+    }
+
+    /**
+     * @param string $name fully qualified attribute name: a leading `\` is accepted, and stripped
+     * @param array<array-key, mixed> $arguments positional (`int` keys) and named (`string` keys) arguments
+     * @throws InvalidArgumentException
+     */
+    public static function fromName(string $name, array $arguments = []): self
+    {
+        $normalizedName = ltrim($name, '\\');
+
+        if (! preg_match(self::NAME_PATTERN, $normalizedName)) {
+            throw new InvalidArgumentException(sprintf(
+                'Provided attribute name "%s" is not a valid class name',
+                $name
+            ));
+        }
+
+        assert('' !== $normalizedName);
+
+        self::assertValidArgumentOrder($arguments);
+
+        return new self($normalizedName, $arguments);
+    }
+
+    /**
+     * @template T of object
+     * @param ReflectionAttribute<T> $reflectionAttribute
+     * @throws InvalidArgumentException
+     */
+    public static function fromReflectionAttribute(ReflectionAttribute $reflectionAttribute): self
+    {
+        return self::fromName($reflectionAttribute->getName(), $reflectionAttribute->getArguments());
+    }
+
+    /**
+     * @return list<self>
+     * @throws InvalidArgumentException
+     */
+    public static function fromReflector(
+        ReflectionClass|ReflectionClassConstant|ReflectionFunction
+        |ReflectionMethod|ReflectionParameter|ReflectionProperty $reflector
+    ): array {
+        $attributes = [];
+
+        foreach ($reflector->getAttributes() as $attribute) {
+            $attributes[] = self::fromReflectionAttribute($attribute);
+        }
+
+        return $attributes;
+    }
+
+    /** @return non-empty-string */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /** @return array<array-key, mixed> */
+    public function getArguments(): array
+    {
+        return $this->arguments;
+    }
+
+    /**
+     * @return non-empty-string
+     * @throws InvalidArgumentException
+     */
+    public function generate(): string
+    {
+        if ([] === $this->arguments) {
+            return '#[\\' . $this->name . ']';
+        }
+
+        $arguments = [];
+
+        /** @var mixed $value */
+        foreach ($this->arguments as $key => $value) {
+            $arguments[] = is_int($key)
+                ? self::generateValue($value)
+                : $key . ': ' . self::generateValue($value);
+        }
+
+        return '#[\\' . $this->name . '(' . implode(', ', $arguments) . ')]';
+    }
+
+    /**
+     * Named arguments cannot be followed by positional ones: rejecting that upfront
+     * prevents the generation of code that cannot be parsed.
+     *
+     * @param array<array-key, mixed> $arguments
+     * @throws InvalidArgumentException
+     */
+    private static function assertValidArgumentOrder(array $arguments): void
+    {
+        $namedArgumentSeen = false;
+
+        foreach (array_keys($arguments) as $key) {
+            if (is_string($key)) {
+                if ('' === $key || ! preg_match(self::ARGUMENT_NAME_PATTERN, $key)) {
+                    throw new InvalidArgumentException(sprintf(
+                        'Provided argument name "%s" is not a valid parameter name',
+                        $key
+                    ));
+                }
+
+                $namedArgumentSeen = true;
+
+                continue;
+            }
+
+            if ($namedArgumentSeen) {
+                throw new InvalidArgumentException(
+                    'Positional arguments cannot follow named arguments in an attribute declaration'
+                );
+            }
+        }
+    }
+
+    /**
+     * Attribute arguments are constant expressions: only a strict subset of PHP values
+     * can be represented in them.
+     *
+     * @throws InvalidArgumentException
+     * @psalm-pure
+     */
+    private static function generateValue(mixed $value): string
+    {
+        if (null === $value) {
+            return 'null';
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_int($value)) {
+            return (string) $value;
+        }
+
+        if (is_float($value)) {
+            // `var_export()` is the only reliable way to keep the value a float in the generated code
+            return var_export($value, true);
+        }
+
+        if (is_string($value)) {
+            return "'" . addcslashes($value, "\\'") . "'";
+        }
+
+        if ($value instanceof UnitEnum) {
+            /** @psalm-suppress ImpurePropertyFetch enum cases are immutable by design */
+            return '\\' . $value::class . '::' . $value->name;
+        }
+
+        if (is_array($value)) {
+            return '[' . implode(', ', self::generateArrayEntries($value)) . ']';
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Type "%s" cannot be used as an attribute argument',
+            get_debug_type($value)
+        ));
+    }
+
+    /**
+     * @param array<array-key, mixed> $value
+     * @return list<string>
+     * @throws InvalidArgumentException
+     * @psalm-pure
+     */
+    private static function generateArrayEntries(array $value): array
+    {
+        if (array_is_list($value)) {
+            return array_map(self::generateValue(...), $value);
+        }
+
+        $entries = [];
+
+        /** @var mixed $item */
+        foreach ($value as $key => $item) {
+            $entries[] = self::generateValue($key) . ' => ' . self::generateValue($item);
+        }
+
+        return $entries;
+    }
+}

--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -68,6 +68,9 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
     /** @var TraitUsageGenerator Object to encapsulate trait usage logic */
     protected TraitUsageGenerator $traitUsageGenerator;
 
+    /** @var list<AttributeGenerator> */
+    protected array $attributes = [];
+
     /**
      * Build a Code Generation Php Object from a Class Reflection
      *
@@ -348,6 +351,39 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
     public function getDocBlock()
     {
         return $this->docBlock;
+    }
+
+    /**
+     * Replaces all the attributes declared on this class
+     *
+     * @param list<AttributeGenerator> $attributes
+     * @return static
+     */
+    public function setAttributes(array $attributes)
+    {
+        $this->attributes = [];
+
+        foreach ($attributes as $attribute) {
+            $this->addAttribute($attribute);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return static
+     */
+    public function addAttribute(AttributeGenerator $attribute)
+    {
+        $this->attributes[] = $attribute;
+
+        return $this;
+    }
+
+    /** @return list<AttributeGenerator> */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
     }
 
     /**
@@ -1062,6 +1098,10 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
         if (null !== ($docBlock = $this->getDocBlock())) {
             $docBlock->setIndentation('');
             $output .= $docBlock->generate();
+        }
+
+        foreach ($this->attributes as $attribute) {
+            $output .= $attribute->generate() . self::LINE_FEED;
         }
 
         if ($this->isAbstract()) {

--- a/test/Generator/AttributeGeneratorTest.php
+++ b/test/Generator/AttributeGeneratorTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace LaminasTest\Code\Generator;
+
+use Laminas\Code\Generator\AttributeGenerator;
+use Laminas\Code\Generator\Exception\InvalidArgumentException;
+use LaminasTest\Code\Generator\TestAsset\AttributeAsset;
+use LaminasTest\Code\Generator\TestAsset\ClassWithAttributes;
+use LaminasTest\Code\Generator\TestAsset\ClassWithInterface;
+use LaminasTest\Code\Generator\TestAsset\TestEnum;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+use stdClass;
+
+use function array_map;
+
+#[CoversClass(AttributeGenerator::class)]
+final class AttributeGeneratorTest extends TestCase
+{
+    /** @param array<array-key, mixed> $arguments */
+    #[DataProvider('validAttributes')]
+    public function testGeneratesExpectedCode(string $name, array $arguments, string $expected): void
+    {
+        self::assertSame($expected, AttributeGenerator::fromName($name, $arguments)->generate());
+    }
+
+    /** @return array<non-empty-string, array{string, array<array-key, mixed>, string}> */
+    public static function validAttributes(): array
+    {
+        return [
+            'no arguments'          => ['Foo', [], '#[\Foo]'],
+            'leading backslash'     => ['\Foo\Bar', [], '#[\Foo\Bar]'],
+            'positional arguments'  => ['Foo', [1, 'a'], "#[\Foo(1, 'a')]"],
+            'named arguments'       => [
+                'Foo',
+                ['first' => true, 'second' => null],
+                '#[\Foo(first: true, second: null)]',
+            ],
+            'mixed arguments'       => ['Foo', [0 => 1, 'named' => 2], '#[\Foo(1, named: 2)]'],
+            'float keeps its type'  => ['Foo', [1.0], '#[\Foo(1.0)]'],
+            'negative float'        => ['Foo', [-0.5], '#[\Foo(-0.5)]'],
+            'escaped string'        => ['Foo', ["a'b\\c"], "#[\Foo('a\\'b\\\\c')]"],
+            'list argument'         => ['Foo', [[1, 2]], '#[\Foo([1, 2])]'],
+            'hash argument'         => ['Foo', [['a' => 1]], "#[\Foo(['a' => 1])]"],
+            'nested array argument' => ['Foo', [[[1], ['b' => 2]]], "#[\Foo([[1], ['b' => 2]])]"],
+            'sparse list argument'  => ['Foo', [[3 => 'a']], "#[\Foo([3 => 'a'])]"],
+            'enum case argument'    => [
+                'Foo',
+                [TestEnum::Test1],
+                '#[\Foo(\LaminasTest\Code\Generator\TestAsset\TestEnum::Test1)]',
+            ],
+        ];
+    }
+
+    public function testRejectsInvalidAttributeName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Provided attribute name "1nvalid" is not a valid class name');
+
+        AttributeGenerator::fromName('1nvalid');
+    }
+
+    public function testRejectsEmptyAttributeName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        AttributeGenerator::fromName('');
+    }
+
+    public function testRejectsInvalidArgumentName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Provided argument name "not a name" is not a valid parameter name');
+
+        AttributeGenerator::fromName('Foo', ['not a name' => 1]);
+    }
+
+    public function testRejectsPositionalArgumentsAfterNamedOnes(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Positional arguments cannot follow named arguments in an attribute declaration'
+        );
+
+        AttributeGenerator::fromName('Foo', ['named' => 1, 2]);
+    }
+
+    public function testRejectsValuesThatAreNotConstantExpressions(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Type "stdClass" cannot be used as an attribute argument');
+
+        AttributeGenerator::fromName('Foo', [new stdClass()])->generate();
+    }
+
+    public function testRejectsValuesThatAreNotConstantExpressionsWhenNested(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        AttributeGenerator::fromName('Foo', [['nested' => new stdClass()]])->generate();
+    }
+
+    public function testExposesNameAndArguments(): void
+    {
+        $attribute = AttributeGenerator::fromName('\Foo\Bar', ['baz' => 1]);
+
+        self::assertSame('Foo\Bar', $attribute->getName());
+        self::assertSame(['baz' => 1], $attribute->getArguments());
+    }
+
+    public function testFromReflectionAttribute(): void
+    {
+        $attributes = (new ReflectionClass(ClassWithAttributes::class))->getAttributes(AttributeAsset::class);
+
+        self::assertSame(
+            '#[\LaminasTest\Code\Generator\TestAsset\AttributeAsset]',
+            AttributeGenerator::fromReflectionAttribute($attributes[0])->generate()
+        );
+    }
+
+    public function testFromReflectorOnClass(): void
+    {
+        self::assertSame(
+            [
+                '#[\LaminasTest\Code\Generator\TestAsset\AttributeAsset]',
+                "#[\LaminasTest\Code\Generator\TestAsset\AttributeAsset(stringArgument: 'any string', intArgument: 1)]",
+            ],
+            self::generateAll(AttributeGenerator::fromReflector(new ReflectionClass(ClassWithAttributes::class)))
+        );
+    }
+
+    public function testFromReflectorOnMethodPropertyAndParameter(): void
+    {
+        $method = new ReflectionMethod(ClassWithAttributes::class, 'method');
+
+        self::assertSame(
+            ["#[\LaminasTest\Code\Generator\TestAsset\AttributeAsset(stringArgument: 'on a method')]"],
+            self::generateAll(AttributeGenerator::fromReflector($method))
+        );
+
+        self::assertSame(
+            ["#[\LaminasTest\Code\Generator\TestAsset\AttributeAsset(stringArgument: 'on a property')]"],
+            self::generateAll(AttributeGenerator::fromReflector(
+                new ReflectionProperty(ClassWithAttributes::class, 'property')
+            ))
+        );
+
+        self::assertSame(
+            ['#[\LaminasTest\Code\Generator\TestAsset\AttributeAsset]'],
+            self::generateAll(AttributeGenerator::fromReflector($method->getParameters()[0]))
+        );
+    }
+
+    public function testFromReflectorOnUnannotatedSymbolProducesNoAttributes(): void
+    {
+        self::assertSame([], AttributeGenerator::fromReflector(new ReflectionClass(ClassWithInterface::class)));
+    }
+
+    /**
+     * @param list<AttributeGenerator> $attributes
+     * @return list<string>
+     */
+    private static function generateAll(array $attributes): array
+    {
+        return array_map(static fn (AttributeGenerator $attribute): string => $attribute->generate(), $attributes);
+    }
+}

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -3,6 +3,7 @@
 namespace LaminasTest\Code\Generator;
 
 use DateTime;
+use Laminas\Code\Generator\AttributeGenerator;
 use Laminas\Code\Generator\ClassGenerator;
 use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\Exception\ExceptionInterface;
@@ -1424,5 +1425,64 @@ EOS;
         // @phpcs:enable
 
         self::assertEquals($expectedOutput, $classGenerator->generate());
+    }
+
+    public function testGeneratesClassLevelAttributes(): void
+    {
+        $classGenerator = new ClassGenerator('MyClass');
+
+        $classGenerator->setAttributes([
+            AttributeGenerator::fromName('Foo'),
+            AttributeGenerator::fromName('\Bar\Baz', ['first' => 1, 'second' => 'two']),
+        ]);
+
+        $expectedOutput = <<<'EOS'
+#[\Foo]
+#[\Bar\Baz(first: 1, second: 'two')]
+class MyClass
+{
+}
+
+EOS;
+
+        self::assertSame($expectedOutput, $classGenerator->generate());
+    }
+
+    public function testAttributesArePlacedBetweenDocBlockAndClassDeclaration(): void
+    {
+        $classGenerator = new ClassGenerator('MyClass');
+
+        $classGenerator->setDocBlock(new DocBlockGenerator('A description'));
+        $classGenerator->addAttribute(AttributeGenerator::fromName('Foo'));
+        $classGenerator->setFinal(true);
+
+        $expectedOutput = <<<'EOS'
+/**
+ * A description
+ */
+#[\Foo]
+final class MyClass
+{
+}
+
+EOS;
+
+        self::assertSame($expectedOutput, $classGenerator->generate());
+    }
+
+    public function testAttributesCanBeRetrievedAndReplaced(): void
+    {
+        $classGenerator = new ClassGenerator('MyClass');
+        $attribute      = AttributeGenerator::fromName('Foo');
+
+        self::assertSame([], $classGenerator->getAttributes());
+
+        $classGenerator->addAttribute($attribute);
+
+        self::assertSame([$attribute], $classGenerator->getAttributes());
+
+        $classGenerator->setAttributes([]);
+
+        self::assertSame([], $classGenerator->getAttributes());
     }
 }

--- a/test/Generator/TestAsset/AttributeAsset.php
+++ b/test/Generator/TestAsset/AttributeAsset.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LaminasTest\Code\Generator\TestAsset;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_ALL | Attribute::IS_REPEATABLE)]
+final class AttributeAsset
+{
+    public function __construct(
+        public readonly ?string $stringArgument = null,
+        public readonly ?int $intArgument = null,
+        public readonly ?array $arrayArgument = null,
+    ) {
+    }
+}

--- a/test/Generator/TestAsset/ClassWithAttributes.php
+++ b/test/Generator/TestAsset/ClassWithAttributes.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LaminasTest\Code\Generator\TestAsset;
+
+#[AttributeAsset]
+#[AttributeAsset(stringArgument: 'any string', intArgument: 1)]
+final class ClassWithAttributes
+{
+    #[AttributeAsset(stringArgument: 'on a property')]
+    public string $property = '';
+
+    #[AttributeAsset(stringArgument: 'on a method')]
+    public function method(#[AttributeAsset] string $parameter = ''): void
+    {
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

`Laminas\Code\Generator` currently has no way to emit PHP attributes, so any class generated
through this library loses them. This is a long-standing gap: attributes have been part of the
language since PHP 8.0, and consumers such as proxy generators and ORM/DI tooling need to emit
them. See #144, and the earlier attempt in #145.

This PR adds `Laminas\Code\Generator\AttributeGenerator` plus attribute support on
`ClassGenerator` (and, by inheritance, `InterfaceGenerator` and `TraitGenerator`). It targets
`4.18.x` as a new feature, and is fully backwards compatible: no existing behaviour changes, and
no existing output changes.

#### How the code is used

```php
$class = new ClassGenerator('MyEntity');
$class->setAttributes([
    AttributeGenerator::fromName(Entity::class),
    AttributeGenerator::fromName(Table::class, ['name' => 'my_entity']),
]);
$class->addAttribute(AttributeGenerator::fromName('My\Attributes\Deprecated', ['since 1.2.0']));

echo $class->generate();
```

```php
#[\Doctrine\ORM\Mapping\Entity]
#[\Doctrine\ORM\Mapping\Table(name: 'my_entity')]
#[\My\Attributes\Deprecated('since 1.2.0')]
class MyEntity
{
}
```

Attributes on existing symbols can be read back through reflection:

```php
// list<AttributeGenerator>
$attributes = AttributeGenerator::fromReflector(new ReflectionClass(MyEntity::class));
```

#### Public API

- `AttributeGenerator::fromName(string $name, array $arguments = []): self`
- `AttributeGenerator::fromReflectionAttribute(ReflectionAttribute $attribute): self`
- `AttributeGenerator::fromReflector(ReflectionClass|ReflectionClassConstant|ReflectionFunction|ReflectionMethod|ReflectionParameter|ReflectionProperty $reflector): list<self>`
- `AttributeGenerator#generate(): string`, `#getName()`, `#getArguments()`
- `ClassGenerator#setAttributes(list<AttributeGenerator>)`, `#addAttribute()`, `#getAttributes()`

Everything else is `private`. The class is `final`, `@psalm-immutable`, implements
`GeneratorInterface` only, and is not `Stringable`.

#### Design notes

This is a fresh implementation rather than a rebase of #145, written against the design direction
requested there by @Ocramius: a single class with a thin `public` API and no separate
assembler/builder/factory layer.

- **No `::fromArray()`**, per #153.
- **No `AttributeBuilder` / `AttributeAssembler` / `AttributeAssemblerFactory` / `AttributePart`.**
  Since the assembler layer is gone, the open "should `AttributePart` become an enum" question from
  #145 no longer applies: there is no part type left to model.
- **Names are always emitted fully qualified** (`#[\Foo\Bar]`), so output is valid regardless of the
  surrounding `use` statements. A leading `\` in the input is accepted and normalised away.
- **Argument values are rendered by a private renderer rather than `ValueGenerator`.** Attribute
  arguments are constant expressions with different rules than property defaults, and
  `ValueGenerator` renders `1.0` as `1`, silently changing the argument's type. Supported values:
  `null`, `bool`, `int`, `float`, `string`, `array` (recursive, list and hash) and enum cases.
  Anything else throws `InvalidArgumentException`.
- **Invalid input fails at construction time** where practical: malformed attribute names,
  malformed argument names, and positional arguments following named ones are all rejected by
  `fromName()`.
- **`ClassGenerator::fromReflection()` deliberately does not populate attributes.** Doing so would
  silently change the output for every existing consumer that generates classes from reflection —
  proxy generators in particular. Attributes are opt-in via `AttributeGenerator::fromReflector()`.

#### Scope

Class-level attributes only, matching the issue. Attributes on methods, properties, constants and
parameters are a natural follow-up and reuse `AttributeGenerator` unchanged — happy to add them in
a separate PR once the shape of this one is agreed.

Documentation is included in `docs/book/generator/examples.md`. `composer cs-check`,
`composer test` and `composer static-analysis` all pass locally.

Fixes #144
